### PR TITLE
Use latest main of object_store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ flate2 = "1.0.20"
 futures = "0.3.31"
 jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false }
 num_enum = "0.7.3"
-object_store = "0.11"
+# Match the version used by pyo3-object-store
+object_store = { git = "https://github.com/apache/arrow-rs", rev = "7a15e4b47ca97df2edef689c9f2ebd2f3888b79e" }
 thiserror = "1"
 tiff = "0.9"
 tokio = { version = "1.43.0", optional = true }

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -529,12 +529,12 @@ impl ImageFileDirectory {
         }
     }
 
-    fn get_tile_byte_range(&self, x: usize, y: usize) -> Range<usize> {
+    fn get_tile_byte_range(&self, x: usize, y: usize) -> Range<u64> {
         let idx = (y * self.tile_count().0) + x;
         let offset = self.tile_offsets[idx] as usize;
         // TODO: aiocogeo has a -1 here, but I think that was in error
         let byte_count = self.tile_byte_counts[idx] as usize;
-        offset..offset + byte_count
+        offset as _..(offset + byte_count) as _
     }
 
     pub async fn get_tile(


### PR DESCRIPTION
This pins to the same commit used by `pyo3-object_store`, which should make it easier to test out a Python package.

cc @maxrjones 