### PR TITLE
Prefetch reader

### DIFF
--- a/python/tests/test_cog.py
+++ b/python/tests/test_cog.py
@@ -6,11 +6,16 @@ store = S3Store("sentinel-cogs", region="us-west-2", skip_signature=True)
 path = "sentinel-s2-l2a-cogs/12/S/UF/2022/6/S2B_12SUF_20220609_0_L2A/B04.tif"
 
 # 2 min, 15s
-tiff = await TIFF.open(path, store=store)
+tiff = await TIFF.open(path, store=store, prefetch=32768)
 ifds = tiff.ifds()
 ifd = ifds[0]
+ifd.compression
 ifd.tile_height
 ifd.tile_width
 ifd.photometric_interpretation
 gkd = ifd.geo_key_directory
 gkd.citation
+gkd.projected_type
+gkd.citation
+
+dir(gkd)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,6 @@ pub mod error;
 pub mod geo;
 mod ifd;
 
-pub use async_reader::{AsyncFileReader, ObjectReader};
+pub use async_reader::{AsyncFileReader, ObjectReader, PrefetchReader};
 pub use cog::COGReader;
 pub use ifd::{ImageFileDirectories, ImageFileDirectory};


### PR DESCRIPTION
Allows for fetching first X kb of a file, and then delegating further requests to this cached buffer.

This caused the Python file open to reduce from 2.5 minutes to 0.7sec

cc @geospatial-jeff. Because this is implemented as a middleware, we could implement whatever sort of cache we want here, like a block cache.