### PR TITLE
Custom decoder registry

### DIFF
--- a/python/python/async_tiff/_decoder.pyi
+++ b/python/python/async_tiff/_decoder.pyi
@@ -1,0 +1,12 @@
+from typing import Protocol
+from collections.abc import Buffer
+
+from .enums import CompressionMethod
+
+class Decoder(Protocol):
+    @staticmethod
+    def __call__(buffer: Buffer) -> Buffer: ...
+
+class DecoderRegistry:
+    def __init__(self) -> None: ...
+    def add(self, compression: CompressionMethod | int, decoder: Decoder) -> None: ...

--- a/python/src/decoder.rs
+++ b/python/src/decoder.rs
@@ -1,0 +1,63 @@
+use async_tiff::decoder::{Decoder, DecoderRegistry};
+use async_tiff::error::AiocogeoError;
+use bytes::Bytes;
+use pyo3::exceptions::PyTypeError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyTuple};
+use pyo3_bytes::PyBytes;
+
+use crate::enums::PyCompressionMethod;
+
+#[pyclass(name = "DecoderRegistry")]
+pub(crate) struct PyDecoderRegistry(DecoderRegistry);
+
+#[pymethods]
+impl PyDecoderRegistry {
+    #[new]
+    fn new() -> Self {
+        Self(DecoderRegistry::default())
+    }
+
+    fn add(&mut self, compression: PyCompressionMethod, decoder: PyDecoder) {
+        self.0
+            .as_mut()
+            .insert(compression.into(), Box::new(decoder));
+    }
+}
+
+#[derive(Debug)]
+struct PyDecoder(PyObject);
+
+impl PyDecoder {
+    fn call(&self, py: Python, buffer: Bytes) -> PyResult<PyBytes> {
+        let kwargs = PyDict::new(py);
+        kwargs.set_item(intern!(py, "buffer"), PyBytes::new(buffer))?;
+        let result = self.0.call(py, PyTuple::empty(py), Some(&kwargs))?;
+        result.extract(py)
+    }
+}
+
+impl<'py> FromPyObject<'py> for PyDecoder {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if !ob.hasattr(intern!(ob.py(), "__call__"))? {
+            return Err(PyTypeError::new_err(
+                "Expected callable object for custom decoder.",
+            ));
+        }
+        Ok(Self(ob.clone().unbind()))
+    }
+}
+
+impl Decoder for PyDecoder {
+    fn decode_tile(
+        &self,
+        buffer: bytes::Bytes,
+        _photometric_interpretation: tiff::tags::PhotometricInterpretation,
+        _jpeg_tables: Option<&[u8]>,
+    ) -> async_tiff::error::Result<bytes::Bytes> {
+        let decoded_buffer = Python::with_gil(|py| self.call(py, buffer))
+            .map_err(|err| AiocogeoError::General(err.to_string()))?;
+        Ok(decoded_buffer.into_inner())
+    }
+}

--- a/python/src/enums.rs
+++ b/python/src/enums.rs
@@ -14,6 +14,18 @@ impl From<CompressionMethod> for PyCompressionMethod {
     }
 }
 
+impl From<PyCompressionMethod> for CompressionMethod {
+    fn from(value: PyCompressionMethod) -> Self {
+        value.0
+    }
+}
+
+impl<'py> FromPyObject<'py> for PyCompressionMethod {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Ok(Self(CompressionMethod::from_u16_exhaustive(ob.extract()?)))
+    }
+}
+
 impl<'py> IntoPyObject<'py> for PyCompressionMethod {
     type Target = PyAny;
     type Output = Bound<'py, PyAny>;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 
+mod decoder;
 mod enums;
 mod geo;
 mod ifd;
@@ -7,6 +8,7 @@ mod tiff;
 
 use pyo3::prelude::*;
 
+use crate::decoder::PyDecoderRegistry;
 use crate::geo::PyGeoKeyDirectory;
 use crate::ifd::PyImageFileDirectory;
 use crate::tiff::PyTIFF;
@@ -43,6 +45,7 @@ fn _async_tiff(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
     check_debug_build(py)?;
 
     m.add_wrapped(wrap_pyfunction!(___version))?;
+    m.add_class::<PyDecoderRegistry>()?;
     m.add_class::<PyGeoKeyDirectory>()?;
     m.add_class::<PyImageFileDirectory>()?;
     m.add_class::<PyTIFF>()?;

--- a/src/cog.rs
+++ b/src/cog.rs
@@ -49,6 +49,7 @@ mod test {
     use std::io::BufReader;
     use std::sync::Arc;
 
+    use crate::decoder::DecoderRegistry;
     use crate::ObjectReader;
 
     use super::*;
@@ -66,7 +67,11 @@ mod test {
         let cog_reader = COGReader::try_open(Box::new(reader.clone())).await.unwrap();
 
         let ifd = &cog_reader.ifds.as_ref()[1];
-        let tile = ifd.get_tile(0, 0, Box::new(reader)).await.unwrap();
+        let decoder_registry = DecoderRegistry::default();
+        let tile = ifd
+            .get_tile(0, 0, Box::new(reader), &decoder_registry)
+            .await
+            .unwrap();
         std::fs::write("img.buf", tile).unwrap();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod async_reader;
 mod cog;
-mod decoder;
+pub mod decoder;
 pub mod error;
 pub mod geo;
 mod ifd;


### PR DESCRIPTION
### Change list

- Adds public `Decoder` trait and public `DecoderRegistry` struct.
- Allows users to pass in their own custom decoders, either from the Rust or Python side.
- Allows users to override the default implementations of decoders used.
