### PR TITLE
Split tile fetching and decoding

### DIFF
--- a/python/python/async_tiff/_decoder.pyi
+++ b/python/python/async_tiff/_decoder.pyi
@@ -4,6 +4,8 @@ from collections.abc import Buffer
 from .enums import CompressionMethod
 
 class Decoder(Protocol):
+    # In the future, we could pass in photometric interpretation and jpeg tables as
+    # well.
     @staticmethod
     def __call__(buffer: Buffer) -> Buffer: ...
 

--- a/src/cog.rs
+++ b/src/cog.rs
@@ -96,10 +96,8 @@ mod test {
 
         let ifd = &cog_reader.ifds.as_ref()[1];
         let decoder_registry = DecoderRegistry::default();
-        let tile = ifd
-            .get_tile(0, 0, Box::new(reader), &decoder_registry)
-            .await
-            .unwrap();
+        let tile = ifd.fetch_tile(0, 0, &reader).await.unwrap();
+        let tile = tile.decode(&decoder_registry).unwrap();
         std::fs::write("img.buf", tile).unwrap();
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -116,26 +116,6 @@ impl Decoder for UncompressedDecoder {
     }
 }
 
-// https://github.com/image-rs/image-tiff/blob/3bfb43e83e31b0da476832067ada68a82b378b7b/src/decoder/image.rs#L370
-pub(crate) fn decode_tile(
-    buf: Bytes,
-    photometric_interpretation: PhotometricInterpretation,
-    compression_method: CompressionMethod,
-    // compressed_length: u64,
-    jpeg_tables: Option<&[u8]>,
-    decoder_registry: &DecoderRegistry,
-) -> Result<Bytes> {
-    let decoder =
-        decoder_registry
-            .0
-            .get(&compression_method)
-            .ok_or(TiffError::UnsupportedError(
-                TiffUnsupportedError::UnsupportedCompressionMethod(compression_method),
-            ))?;
-
-    decoder.decode_tile(buf, photometric_interpretation, jpeg_tables)
-}
-
 // https://github.com/image-rs/image-tiff/blob/3bfb43e83e31b0da476832067ada68a82b378b7b/src/decoder/image.rs#L389-L450
 fn decode_modern_jpeg(
     buf: Bytes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod geo;
 mod ifd;
 pub mod tiff;
+mod tile;
 
 pub use async_reader::{AsyncFileReader, ObjectReader, PrefetchReader};
 pub use cog::COGReader;

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -1,0 +1,77 @@
+use bytes::Bytes;
+
+use crate::decoder::DecoderRegistry;
+use crate::error::Result;
+use crate::tiff::tags::{CompressionMethod, PhotometricInterpretation};
+use crate::tiff::{TiffError, TiffUnsupportedError};
+
+/// A TIFF Tile response.
+///
+/// This contains the required information to decode the tile. Decoding is separated from fetching
+/// so that sync and async operations can be separated and non-blocking.
+///
+/// This is returned by `fetch_tile`.
+#[derive(Debug)]
+pub struct TiffTile {
+    pub(crate) x: usize,
+    pub(crate) y: usize,
+    pub(crate) compressed_bytes: Bytes,
+    pub(crate) compression_method: CompressionMethod,
+    pub(crate) photometric_interpretation: PhotometricInterpretation,
+    pub(crate) jpeg_tables: Option<Bytes>,
+}
+
+impl TiffTile {
+    /// The column index of this tile.
+    pub fn x(&self) -> usize {
+        self.x
+    }
+
+    /// The row index of this tile.
+    pub fn y(&self) -> usize {
+        self.y
+    }
+
+    /// Access the compressed bytes underlying this tile.
+    ///
+    /// Note that [`Bytes`] is reference-counted, so it is very cheap to clone if needed.
+    pub fn compressed_bytes(&self) -> &Bytes {
+        &self.compressed_bytes
+    }
+
+    /// Access the compression tag representing this tile.
+    pub fn compression_method(&self) -> CompressionMethod {
+        self.compression_method
+    }
+
+    /// Access the photometric interpretation tag representing this tile.
+    pub fn photometric_interpretation(&self) -> PhotometricInterpretation {
+        self.photometric_interpretation
+    }
+
+    /// Access the JPEG Tables, if any, from the IFD producing this tile.
+    ///
+    /// Note that [`Bytes`] is reference-counted, so it is very cheap to clone if needed.
+    pub fn jpeg_tables(&self) -> Option<&Bytes> {
+        self.jpeg_tables.as_ref()
+    }
+
+    /// Decode this tile.
+    ///
+    /// Decoding is separate from fetching so that sync and async operations do not block the same
+    /// runtime.
+    pub fn decode(&self, decoder_registry: &DecoderRegistry) -> Result<Bytes> {
+        let decoder = decoder_registry
+            .as_ref()
+            .get(&self.compression_method)
+            .ok_or(TiffError::UnsupportedError(
+                TiffUnsupportedError::UnsupportedCompressionMethod(self.compression_method),
+            ))?;
+
+        decoder.decode_tile(
+            self.compressed_bytes.clone(),
+            self.photometric_interpretation,
+            self.jpeg_tables.as_deref(),
+        )
+    }
+}


### PR DESCRIPTION
### Change list

- Rename `get_tile` to `fetch_tile`, which returns a `TiffTile`
- The `TiffTile` contains the information needed to decode the tile content.
- Convert data access methods on AsyncFileReader to non-exclusive reference

For https://github.com/developmentseed/async-tiff/issues/31