### PR TITLE
Reuse obstore.store type hinting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python/obstore"]
+	path = python/_obstore
+	url = https://github.com/developmentseed/obstore

--- a/python/python/async_tiff/__init__.py
+++ b/python/python/async_tiff/__init__.py
@@ -1,4 +1,9 @@
+from typing import TYPE_CHECKING
+
 from ._async_tiff import *
 from ._async_tiff import ___version
+
+if TYPE_CHECKING:
+    from . import store
 
 __version__: str = ___version()

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -1,11 +1,10 @@
-from typing import Any
-
 from ._ifd import ImageFileDirectory
+from .store import ObjectStore
 
 class TIFF:
     @classmethod
     async def open(
-        cls, path: str, *, store: Any, prefetch: int | None = 16384
+        cls, path: str, *, store: ObjectStore, prefetch: int | None = 16384
     ) -> TIFF: ...
     @property
     def ifds(self) -> list[ImageFileDirectory]: ...

--- a/python/python/async_tiff/store
+++ b/python/python/async_tiff/store
@@ -1,0 +1,1 @@
+../../_obstore/obstore/python/obstore/store


### PR DESCRIPTION
When obstore gets an 0.5 release, we can pin our submodule to that.