### PR TITLE
aiohttp backend

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4,6 +4,7 @@ mod decoder;
 mod enums;
 mod geo;
 mod ifd;
+mod reader;
 mod thread_pool;
 mod tiff;
 mod tile;

--- a/python/src/reader/aiohttp.rs
+++ b/python/src/reader/aiohttp.rs
@@ -1,0 +1,28 @@
+use pyo3::exceptions::PyTypeError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedStr;
+
+struct AiohttpSession(PyObject);
+
+impl<'py> FromPyObject<'py> for AiohttpSession {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let py = ob.py();
+        let cls = ob.getattr(intern!(py, "__class__"))?;
+        let module = cls
+            .getattr(intern!(py, "__module__"))?
+            .extract::<PyBackedStr>()?;
+        let class_name = cls
+            .getattr(intern!(py, "__name__"))?
+            .extract::<PyBackedStr>()?;
+        if module.starts_with("aiohttp") && class_name == "ClientSession" {
+            todo!()
+        } else {
+            let msg = format!(
+                "Expected aiohttp.ClientSession, got {}.{}",
+                module, class_name
+            );
+            Err(PyTypeError::new_err(msg))
+        }
+    }
+}

--- a/python/src/reader/mod.rs
+++ b/python/src/reader/mod.rs
@@ -1,0 +1,1 @@
+mod aiohttp;


### PR DESCRIPTION
We should probably just accept a backend that conforms to [`obspec.GetRangeAsync`](https://developmentseed.org/obspec/latest/api/get/#obspec.GetRangeAsync)

Closes #42