### PR TITLE
Fix wheels; fetch submodule

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -109,36 +109,38 @@ jobs:
           name: wheels-musllinux-${{ matrix.platform.target }}
           path: dist
 
-  windows:
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      matrix:
-        platform:
-          - runner: windows-latest
-            target: x64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
-      # There seem to be linking errors on Windows with the uv-provided Python
-      # executables, so we use the Python versions provided by github actions
-      # for now.
-      # Seems to be this question: https://stackoverflow.com/questions/78557803/python-with-rust-cannot-open-input-file-python3-lib
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.13
-          architecture: ${{ matrix.platform.target }}
-      - name: Build wheels
-        uses: PyO3/maturin-action@v1
-        with:
-          target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path python/Cargo.toml
-          sccache: "true"
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+  # We skip windows for now because the symlinks (for `pyi` typing) give "access denied" on windows.
+
+  # windows:
+  #   runs-on: ${{ matrix.platform.runner }}
+  #   strategy:
+  #     matrix:
+  #       platform:
+  #         - runner: windows-latest
+  #           target: x64
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         submodules: "recursive"
+  #     # There seem to be linking errors on Windows with the uv-provided Python
+  #     # executables, so we use the Python versions provided by github actions
+  #     # for now.
+  #     # Seems to be this question: https://stackoverflow.com/questions/78557803/python-with-rust-cannot-open-input-file-python3-lib
+  #     - uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.13
+  #         architecture: ${{ matrix.platform.target }}
+  #     - name: Build wheels
+  #       uses: PyO3/maturin-action@v1
+  #       with:
+  #         target: ${{ matrix.platform.target }}
+  #         args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path python/Cargo.toml
+  #         sccache: "true"
+  #     - name: Upload wheels
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: wheels-windows-${{ matrix.platform.target }}
+  #         path: dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -202,7 +204,7 @@ jobs:
     #   # IMPORTANT: this permission is mandatory for trusted publishing
     #   id-token: write
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, musllinux, windows, macos]
+    needs: [linux, musllinux, macos]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -44,6 +44,8 @@ jobs:
             manylinux: auto
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -82,6 +84,8 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -114,6 +118,8 @@ jobs:
             target: x64
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
       # There seem to be linking errors on Windows with the uv-provided Python
       # executables, so we use the Python versions provided by github actions
       # for now.
@@ -145,6 +151,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5


### PR DESCRIPTION
Trying to fix the error of 
```
💥 maturin failed
  Caused by: Failed to add the files to the wheel
  Caused by: Failed to add the python module to the package
  Caused by: No such file or directory (os error 2)
```
it's a confusing error but then I got a hunch that it's probably because the submodule isn't fetched, so the symlink can't be followed.