### PR TITLE
Python: Support obspec reader input to TIFF.open

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -992,6 +992,7 @@ version = "0.1.0-beta.2"
 dependencies = [
  "async-tiff",
  "bytes",
+ "futures",
  "object_store",
  "pyo3",
  "pyo3-async-runtimes",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib"]
 [dependencies]
 async-tiff = { path = "../" }
 bytes = "1.10.1"
+futures = "0.3.31"
 object_store = "0.12"
 pyo3 = { version = "0.23.0", features = ["macros"] }
 pyo3-async-runtimes = "0.23"

--- a/python/docs/api/tiff.md
+++ b/python/docs/api/tiff.md
@@ -3,3 +3,4 @@
 ::: async_tiff.TIFF
     options:
         show_if_no_docstring: true
+::: async_tiff.ObspecReader

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "async-tiff"
 requires-python = ">=3.9"
-dependencies = []
+dependencies = ["obspec>=0.1.0-beta.3"]
 dynamic = ["version"]
 classifiers = [
     "Programming Language :: Rust",

--- a/python/python/async_tiff/_async_tiff.pyi
+++ b/python/python/async_tiff/_async_tiff.pyi
@@ -3,5 +3,6 @@ from ._decoder import DecoderRegistry as DecoderRegistry
 from ._geo import GeoKeyDirectory as GeoKeyDirectory
 from ._ifd import ImageFileDirectory as ImageFileDirectory
 from ._thread_pool import ThreadPool as ThreadPool
+from ._tiff import ObspecInput as ObspecInput
 from ._tiff import TIFF as TIFF
 from ._tile import Tile as Tile

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -1,7 +1,13 @@
-import obstore
+from typing import Protocol
 from ._tile import Tile
 from ._ifd import ImageFileDirectory
 from .store import ObjectStore
+
+# Fix exports
+from obspec._get import GetRangeAsync, GetRangesAsync
+
+class ObspecInput(GetRangeAsync, GetRangesAsync, Protocol):
+    """Supported obspec input to reader."""
 
 class TIFF:
     @classmethod
@@ -9,7 +15,7 @@ class TIFF:
         cls,
         path: str,
         *,
-        store: obstore.store.ObjectStore | ObjectStore,
+        store: ObjectStore | ObspecInput,
         prefetch: int | None = 16384,
     ) -> TIFF:
         """Open a new TIFF.

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -4,6 +4,7 @@ mod decoder;
 mod enums;
 mod geo;
 mod ifd;
+mod reader;
 mod thread_pool;
 mod tiff;
 mod tile;

--- a/python/src/reader.rs
+++ b/python/src/reader.rs
@@ -1,0 +1,128 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use async_tiff::error::{AsyncTiffError, AsyncTiffResult};
+use async_tiff::reader::{AsyncFileReader, ObjectReader};
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use pyo3::exceptions::PyTypeError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use pyo3_async_runtimes::tokio::into_future;
+use pyo3_bytes::PyBytes;
+use pyo3_object_store::PyObjectStore;
+
+#[derive(FromPyObject)]
+pub(crate) enum StoreInput {
+    ObjectStore(PyObjectStore),
+    ObspecBackend(ObspecBackend),
+}
+
+impl StoreInput {
+    pub(crate) fn into_async_file_reader(self, path: String) -> Arc<dyn AsyncFileReader> {
+        match self {
+            Self::ObjectStore(store) => {
+                Arc::new(ObjectReader::new(store.into_inner(), path.into()))
+            }
+            Self::ObspecBackend(backend) => Arc::new(ObspecReader { backend, path }),
+        }
+    }
+}
+
+/// A Python backend for making requests that conforms to the GetRangeAsync and GetRangesAsync
+/// protocols defined by obspec.
+/// https://developmentseed.org/obspec/latest/api/get/#obspec.GetRangeAsync
+/// https://developmentseed.org/obspec/latest/api/get/#obspec.GetRangesAsync
+#[derive(Debug)]
+pub(crate) struct ObspecBackend(PyObject);
+
+impl ObspecBackend {
+    async fn get_range(&self, path: &str, range: Range<u64>) -> PyResult<PyBytes> {
+        let future = Python::with_gil(|py| {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item(intern!(py, "path"), path)?;
+            kwargs.set_item(intern!(py, "start"), range.start)?;
+            kwargs.set_item(intern!(py, "end"), range.end)?;
+
+            let coroutine = self
+                .0
+                .call_method(py, intern!(py, "get_range"), (), Some(&kwargs))?;
+            into_future(coroutine.bind(py).clone())
+        })?;
+        let result = future.await?;
+        Python::with_gil(|py| result.extract(py))
+    }
+
+    async fn get_ranges(&self, path: &str, ranges: &[Range<u64>]) -> PyResult<Vec<PyBytes>> {
+        let starts = ranges.iter().map(|r| r.start).collect::<Vec<_>>();
+        let ends = ranges.iter().map(|r| r.end).collect::<Vec<_>>();
+
+        let future = Python::with_gil(|py| {
+            let kwargs = PyDict::new(py);
+            kwargs.set_item(intern!(py, "path"), path)?;
+            kwargs.set_item(intern!(py, "starts"), starts)?;
+            kwargs.set_item(intern!(py, "ends"), ends)?;
+
+            let coroutine = self
+                .0
+                .call_method(py, intern!(py, "get_range"), (), Some(&kwargs))?;
+            into_future(coroutine.bind(py).clone())
+        })?;
+        let result = future.await?;
+        Python::with_gil(|py| result.extract(py))
+    }
+
+    async fn get_range_wrapper(&self, path: &str, range: Range<u64>) -> AsyncTiffResult<Bytes> {
+        let result = self
+            .get_range(path, range)
+            .await
+            .map_err(|err| AsyncTiffError::External(Box::new(err)))?;
+        Ok(result.into_inner())
+    }
+
+    async fn get_ranges_wrapper(
+        &self,
+        path: &str,
+        ranges: Vec<Range<u64>>,
+    ) -> AsyncTiffResult<Vec<Bytes>> {
+        let result = self
+            .get_ranges(path, &ranges)
+            .await
+            .map_err(|err| AsyncTiffError::External(Box::new(err)))?;
+        Ok(result.into_iter().map(|b| b.into_inner()).collect())
+    }
+}
+
+impl<'py> FromPyObject<'py> for ObspecBackend {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let py = ob.py();
+        if ob.hasattr(intern!(py, "get_range_async"))?
+            && ob.hasattr(intern!(py, "get_ranges_async"))?
+        {
+            Ok(Self(ob.clone().unbind()))
+        } else {
+            Err(PyTypeError::new_err("Expected obspec-compatible class with `get_range_async` and `get_ranges_async` method."))
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ObspecReader {
+    backend: ObspecBackend,
+    path: String,
+}
+
+impl AsyncFileReader for ObspecReader {
+    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.backend.get_range_wrapper(&self.path, range).boxed()
+    }
+
+    fn get_byte_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>> {
+        self.backend.get_ranges_wrapper(&self.path, ranges).boxed()
+    }
+}

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -26,6 +26,9 @@ wheels = [
 [[package]]
 name = "async-tiff"
 source = { editable = "." }
+dependencies = [
+    { name = "obspec" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -48,6 +51,7 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [{ name = "obspec", specifier = ">=0.1.0b3" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -972,6 +976,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/29/e8/5da32ffcaa7a72f7ecd82f90c062140a061eb823cb88e90279424e515cf4/numpy-2.2.3-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:ed2cf9ed4e8ebc3b754d398cba12f24359f018b416c380f577bbae112ca52fc9", size = 6809418 },
     { url = "https://files.pythonhosted.org/packages/a8/a9/68aa7076c7656a7308a0f73d0a2ced8c03f282c9fd98fa7ce21c12634087/numpy-2.2.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39261798d208c3095ae4f7bc8eaeb3481ea8c6e03dc48028057d3cbdbdb8937e", size = 16215461 },
     { url = "https://files.pythonhosted.org/packages/17/7f/d322a4125405920401450118dbdc52e0384026bd669939484670ce8b2ab9/numpy-2.2.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:783145835458e60fa97afac25d511d00a1eca94d4a8f3ace9fe2043003c678e4", size = 12839607 },
+]
+
+[[package]]
+name = "obspec"
+version = "0.1.0b3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c7/27e2de129314bed5419405d649bdf050569de5ab76236ece881869d7e489/obspec-0.1.0b3.tar.gz", hash = "sha256:085a4b977fc2c4b5ff8431c8c0a7634411390bf8d0d938ad0d8a0732bf28b6e3", size = 90810 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/4e/88974dfeff571b661127770f2a5a51ff638f96db4d3d391c044f3885b65c/obspec-0.1.0b3-py3-none-any.whl", hash = "sha256:f43ddfc79198ed614492c56c20e1c2a092d0ac368aef167aa3c6daa3115437e9", size = 15503 },
 ]
 
 [[package]]

--- a/src/cog.rs
+++ b/src/cog.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::error::AsyncTiffResult;
 use crate::ifd::ImageFileDirectories;
 use crate::reader::{AsyncCursor, AsyncFileReader};
@@ -13,7 +15,7 @@ impl TIFF {
     /// Open a new TIFF file.
     ///
     /// This will read all the Image File Directories (IFDs) in the file.
-    pub async fn try_open(reader: Box<dyn AsyncFileReader>) -> AsyncTiffResult<Self> {
+    pub async fn try_open(reader: Arc<dyn AsyncFileReader>) -> AsyncTiffResult<Self> {
         let mut cursor = AsyncCursor::try_open_tiff(reader).await?;
         let version = cursor.read_u16().await?;
 
@@ -72,13 +74,13 @@ mod test {
         let folder = "/Users/kyle/github/developmentseed/async-tiff/";
         let path = object_store::path::Path::parse("m_4007307_sw_18_060_20220803.tif").unwrap();
         let store = Arc::new(LocalFileSystem::new_with_prefix(folder).unwrap());
-        let reader = ObjectReader::new(store, path);
+        let reader = Arc::new(ObjectReader::new(store, path));
 
-        let cog_reader = TIFF::try_open(Box::new(reader.clone())).await.unwrap();
+        let cog_reader = TIFF::try_open(reader.clone()).await.unwrap();
 
         let ifd = &cog_reader.ifds.as_ref()[1];
         let decoder_registry = DecoderRegistry::default();
-        let tile = ifd.fetch_tile(0, 0, &reader).await.unwrap();
+        let tile = ifd.fetch_tile(0, 0, reader.as_ref()).await.unwrap();
         let tile = tile.decode(&decoder_registry).unwrap();
         std::fs::write("img.buf", tile).unwrap();
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,10 @@ pub enum AsyncTiffError {
     /// Reqwest error
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
+
+    /// External error
+    #[error(transparent)]
+    External(Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Crate-specific result type.

--- a/tests/image_tiff/util.rs
+++ b/tests/image_tiff/util.rs
@@ -10,6 +10,6 @@ const TEST_IMAGE_DIR: &str = "tests/image_tiff/images/";
 pub(crate) async fn open_tiff(filename: &str) -> TIFF {
     let store = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
     let path = format!("{TEST_IMAGE_DIR}/{filename}");
-    let reader = Box::new(ObjectReader::new(store.clone(), path.as_str().into()));
+    let reader = Arc::new(ObjectReader::new(store.clone(), path.as_str().into()));
     TIFF::try_open(reader).await.unwrap()
 }


### PR DESCRIPTION
Supersedes and closes https://github.com/developmentseed/async-tiff/pull/54, for https://github.com/developmentseed/async-tiff/issues/42.

Allows any input that conforms to [`GetRangeAsync`](https://developmentseed.org/obspec/latest/api/get/#obspec.GetRangeAsync) and [`GetRangesAsync`](https://developmentseed.org/obspec/latest/api/get/#obspec.GetRangesAsync)