### PR TITLE
Read tag data in its entirety from AsyncFileReader.

### DIFF
--- a/python/src/reader.rs
+++ b/python/src/reader.rs
@@ -115,11 +115,15 @@ struct ObspecReader {
 }
 
 impl AsyncFileReader for ObspecReader {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
         self.backend.get_range_wrapper(&self.path, range).boxed()
     }
 
-    fn get_byte_ranges(
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.backend.get_range_wrapper(&self.path, range).boxed()
+    }
+
+    fn get_image_byte_ranges(
         &self,
         ranges: Vec<Range<u64>>,
     ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>> {

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -779,7 +779,7 @@ impl ImageFileDirectory {
         let range = self
             .get_tile_byte_range(x, y)
             .ok_or(AsyncTiffError::General("Not a tiled TIFF".to_string()))?;
-        let compressed_bytes = reader.get_bytes(range).await?;
+        let compressed_bytes = reader.get_image_bytes(range).await?;
         Ok(Tile {
             x,
             y,
@@ -810,7 +810,7 @@ impl ImageFileDirectory {
             .collect::<AsyncTiffResult<Vec<_>>>()?;
 
         // 2: Fetch using `get_ranges
-        let buffers = reader.get_byte_ranges(byte_ranges).await?;
+        let buffers = reader.get_image_byte_ranges(byte_ranges).await?;
 
         // 3: Create tile objects
         let mut tiles = vec![];

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -887,9 +887,9 @@ async fn read_tag_value(
         // value fits in offset field
         let res = cursor.read(value_byte_length).await?;
         if bigtiff {
-            cursor.advance(8-value_byte_length);
+            cursor.advance(8 - value_byte_length);
         } else {
-            cursor.advance(4-value_byte_length);
+            cursor.advance(4 - value_byte_length);
         }
         res
     } else {
@@ -899,7 +899,11 @@ async fn read_tag_value(
         } else {
             cursor.read_u32().await?.into()
         };
-        let reader = cursor.reader().get_bytes(offset..offset+value_byte_length).await?.reader();
+        let reader = cursor
+            .reader()
+            .get_bytes(offset..offset + value_byte_length)
+            .await?
+            .reader();
         EndianAwareReader::new(reader, cursor.endianness())
         // cursor.seek(offset);
         // cursor.read(value_byte_length).await?
@@ -934,18 +938,18 @@ async fn read_tag_value(
 
     match tag_type {
         Type::BYTE | Type::UNDEFINED => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Byte(data.read_u8()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SBYTE => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SignedByte(data.read_i8()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::ASCII => {
             let mut buf = vec![0; count as usize];
@@ -954,95 +958,95 @@ async fn read_tag_value(
                 let v = std::str::from_utf8(&buf)
                     .map_err(|err| AsyncTiffError::General(err.to_string()))?;
                 let v = v.trim_matches(char::from(0));
-                return Ok(Value::Ascii(v.into()));
+                Ok(Value::Ascii(v.into()))
             } else {
                 panic!("Invalid tag");
                 // return Err(TiffError::FormatError(TiffFormatError::InvalidTag));
             }
         }
         Type::SHORT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Short(data.read_u16()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SSHORT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Signed(i32::from(data.read_i16()?)));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::LONG => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Unsigned(data.read_u32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SLONG => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Signed(data.read_i32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::FLOAT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Float(data.read_f32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::DOUBLE => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Double(data.read_f64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::RATIONAL => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Rational(data.read_u32()?, data.read_u32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SRATIONAL => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SRational(data.read_i32()?, data.read_i32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::LONG8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::UnsignedBig(data.read_u64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SLONG8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SignedBig(data.read_i64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::IFD => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Ifd(data.read_u32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::IFD8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::IfdBig(data.read_u64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
     }
 }

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -949,7 +949,7 @@ async fn read_tag_value(
         Type::SBYTE => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
-                v.push(Value::SignedByte(data.read_i8()?));
+                v.push(Value::Signed(data.read_i8()? as i32));
             }
             Ok(Value::List(v))
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -30,12 +30,15 @@ use crate::error::{AsyncTiffError, AsyncTiffResult};
 ///
 /// [`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
 pub trait AsyncFileReader: Debug + Send + Sync {
-    /// Retrieve the bytes in `range`
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>>;
+    /// Retrieve the bytes in `range` as part of a request for header metadata.
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>>;
 
-    /// Retrieve multiple byte ranges. The default implementation will call `get_bytes`
-    /// sequentially
-    fn get_byte_ranges(
+    /// Retrieve the bytes in `range` as part of a request for image data, not header metadata.
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>>;
+
+    /// Retrieve multiple byte ranges as part of a request for image data, not header metadata. The
+    /// default implementation will call `get_image_bytes` sequentially
+    fn get_image_byte_ranges(
         &self,
         ranges: Vec<Range<u64>>,
     ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>> {
@@ -43,7 +46,7 @@ pub trait AsyncFileReader: Debug + Send + Sync {
             let mut result = Vec::with_capacity(ranges.len());
 
             for range in ranges.into_iter() {
-                let data = self.get_bytes(range).await?;
+                let data = self.get_image_bytes(range).await?;
                 result.push(data);
             }
 
@@ -55,15 +58,19 @@ pub trait AsyncFileReader: Debug + Send + Sync {
 
 /// This allows Box<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,
 impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
-        self.as_ref().get_bytes(range)
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.as_ref().get_metadata_bytes(range)
     }
 
-    fn get_byte_ranges(
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.as_ref().get_image_bytes(range)
+    }
+
+    fn get_image_byte_ranges(
         &self,
         ranges: Vec<Range<u64>>,
     ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>> {
-        self.as_ref().get_byte_ranges(ranges)
+        self.as_ref().get_image_byte_ranges(ranges)
     }
 }
 
@@ -89,31 +96,36 @@ impl<T: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin + Send + Debug> Toki
     pub fn new(inner: T) -> Self {
         Self(tokio::sync::Mutex::new(inner))
     }
+
+    async fn make_range_request(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
+        use std::io::SeekFrom;
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let mut file = self.0.lock().await;
+
+        file.seek(SeekFrom::Start(range.start)).await?;
+
+        let to_read = range.end - range.start;
+        let mut buffer = Vec::with_capacity(to_read as usize);
+        let read = file.read(&mut buffer).await? as u64;
+        if read != to_read {
+            return Err(AsyncTiffError::EndOfFile(to_read, read));
+        }
+
+        Ok(buffer.into())
+    }
 }
 
 #[cfg(feature = "tokio")]
 impl<T: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin + Send + Debug> AsyncFileReader
     for TokioReader<T>
 {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
-        use std::io::SeekFrom;
-        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range).boxed()
+    }
 
-        async move {
-            let mut file = self.0.lock().await;
-
-            file.seek(SeekFrom::Start(range.start)).await?;
-
-            let to_read = range.end - range.start;
-            let mut buffer = Vec::with_capacity(to_read as usize);
-            let read = file.read(&mut buffer).await? as u64;
-            if read != to_read {
-                return Err(AsyncTiffError::EndOfFile(to_read, read));
-            }
-
-            Ok(buffer.into())
-        }
-        .boxed()
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range).boxed()
     }
 }
 
@@ -133,19 +145,30 @@ impl ObjectReader {
     pub fn new(store: Arc<dyn object_store::ObjectStore>, path: object_store::path::Path) -> Self {
         Self { store, path }
     }
-}
 
-#[cfg(feature = "object_store")]
-impl AsyncFileReader for ObjectReader {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+    async fn make_range_request(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         let range = range.start as _..range.end as _;
         self.store
             .get_range(&self.path, range)
             .map_err(|e| e.into())
-            .boxed()
+            .await
+    }
+}
+
+#[cfg(feature = "object_store")]
+impl AsyncFileReader for ObjectReader {
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range).boxed()
     }
 
-    fn get_byte_ranges(&self, ranges: Vec<Range<u64>>) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>>
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range).boxed()
+    }
+
+    fn get_image_byte_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>>
     where
         Self: Send,
     {
@@ -177,11 +200,8 @@ impl ReqwestReader {
     pub fn new(client: reqwest::Client, url: reqwest::Url) -> Self {
         Self { client, url }
     }
-}
 
-#[cfg(feature = "reqwest")]
-impl AsyncFileReader for ReqwestReader {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+    fn make_range_request(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
         let url = self.url.clone();
         let client = self.client.clone();
         // HTTP range is inclusive, so we need to subtract 1 from the end
@@ -195,6 +215,17 @@ impl AsyncFileReader for ReqwestReader {
     }
 }
 
+#[cfg(feature = "reqwest")]
+impl AsyncFileReader for ReqwestReader {
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range)
+    }
+
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        self.make_range_request(range)
+    }
+}
+
 /// An AsyncFileReader that caches the first `prefetch` bytes of a file.
 #[derive(Debug)]
 pub struct PrefetchReader {
@@ -205,13 +236,13 @@ pub struct PrefetchReader {
 impl PrefetchReader {
     /// Construct a new PrefetchReader, catching the first `prefetch` bytes of the file.
     pub async fn new(reader: Arc<dyn AsyncFileReader>, prefetch: u64) -> AsyncTiffResult<Self> {
-        let buffer = reader.get_bytes(0..prefetch).await?;
+        let buffer = reader.get_metadata_bytes(0..prefetch).await?;
         Ok(Self { reader, buffer })
     }
 }
 
 impl AsyncFileReader for PrefetchReader {
-    fn get_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+    fn get_metadata_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
         if range.start < self.buffer.len() as _ {
             if range.end < self.buffer.len() as _ {
                 let usize_range = range.start as usize..range.end as usize;
@@ -219,20 +250,29 @@ impl AsyncFileReader for PrefetchReader {
                 async { Ok(result) }.boxed()
             } else {
                 // TODO: reuse partial internal buffer
-                self.reader.get_bytes(range)
+                self.reader.get_metadata_bytes(range)
             }
         } else {
-            self.reader.get_bytes(range)
+            self.reader.get_metadata_bytes(range)
         }
     }
 
-    fn get_byte_ranges(&self, ranges: Vec<Range<u64>>) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>>
+    fn get_image_bytes(&self, range: Range<u64>) -> BoxFuture<'_, AsyncTiffResult<Bytes>> {
+        // In practice, get_image_bytes is only used for fetching tiles, which are unlikely
+        // to overlap a metadata prefetch.
+        self.reader.get_image_bytes(range)
+    }
+
+    fn get_image_byte_ranges(
+        &self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, AsyncTiffResult<Vec<Bytes>>>
     where
         Self: Send,
     {
-        // In practice, get_byte_ranges is only used for fetching tiles, which are unlikely to
-        // overlap a metadata prefetch.
-        self.reader.get_byte_ranges(ranges)
+        // In practice, get_image_byte_ranges is only used for fetching tiles, which are unlikely
+        // to overlap a metadata prefetch.
+        self.reader.get_image_byte_ranges(ranges)
     }
 }
 
@@ -293,7 +333,7 @@ impl AsyncCursor {
     pub(crate) async fn read(&mut self, length: u64) -> AsyncTiffResult<EndianAwareReader> {
         let range = self.offset as _..(self.offset + length) as _;
         self.offset += length;
-        let bytes = self.reader.get_bytes(range).await?;
+        let bytes = self.reader.get_metadata_bytes(range).await?;
         Ok(EndianAwareReader {
             reader: bytes.reader(),
             endianness: self.endianness,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -341,31 +341,37 @@ impl AsyncCursor {
     }
 
     /// Read a u8 from the cursor, advancing the internal state by 1 byte.
+    #[allow(dead_code)]
     pub(crate) async fn read_u8(&mut self) -> AsyncTiffResult<u8> {
         self.read(1).await?.read_u8()
     }
 
     /// Read a i8 from the cursor, advancing the internal state by 1 byte.
+    #[allow(dead_code)]
     pub(crate) async fn read_i8(&mut self) -> AsyncTiffResult<i8> {
         self.read(1).await?.read_i8()
     }
 
     /// Read a u16 from the cursor, advancing the internal state by 2 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_u16(&mut self) -> AsyncTiffResult<u16> {
         self.read(2).await?.read_u16()
     }
 
     /// Read a i16 from the cursor, advancing the internal state by 2 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i16(&mut self) -> AsyncTiffResult<i16> {
         self.read(2).await?.read_i16()
     }
 
     /// Read a u32 from the cursor, advancing the internal state by 4 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_u32(&mut self) -> AsyncTiffResult<u32> {
         self.read(4).await?.read_u32()
     }
 
     /// Read a i32 from the cursor, advancing the internal state by 4 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i32(&mut self) -> AsyncTiffResult<i32> {
         self.read(4).await?.read_i32()
     }
@@ -376,24 +382,25 @@ impl AsyncCursor {
     }
 
     /// Read a i64 from the cursor, advancing the internal state by 8 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i64(&mut self) -> AsyncTiffResult<i64> {
         self.read(8).await?.read_i64()
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn read_f32(&mut self) -> AsyncTiffResult<f32> {
         self.read(4).await?.read_f32()
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn read_f64(&mut self) -> AsyncTiffResult<f64> {
         self.read(8).await?.read_f64()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn reader(&self) -> &Arc<dyn AsyncFileReader> {
         &self.reader
     }
 
-    #[allow(dead_code)]
     pub(crate) fn endianness(&self) -> Endianness {
         self.endianness
     }
@@ -407,6 +414,7 @@ impl AsyncCursor {
         self.offset = offset;
     }
 
+    #[allow(dead_code)]
     pub(crate) fn position(&self) -> u64 {
         self.offset
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -418,6 +418,9 @@ pub(crate) struct EndianAwareReader {
 }
 
 impl EndianAwareReader {
+    pub(crate) fn new(reader: Reader<Bytes>, endianness: Endianness) -> Self {
+        Self { reader, endianness }
+    }
     /// Read a u8 from the cursor, advancing the internal state by 1 byte.
     pub(crate) fn read_u8(&mut self) -> AsyncTiffResult<u8> {
         Ok(self.reader.read_u8()?)

--- a/src/tiff/tags.rs
+++ b/src/tiff/tags.rs
@@ -175,22 +175,6 @@ pub enum Type(u16) {
 }
 }
 
-impl Type {
-    pub const fn size(&self) -> u64 {
-        match self {
-            Type::BYTE | Type::SBYTE | Type::ASCII | Type::UNDEFINED => 1,
-            Type::SHORT | Type::SSHORT => 2,
-            Type::LONG | Type::SLONG | Type::FLOAT | Type::IFD => 4,
-            Type::LONG8
-            | Type::SLONG8
-            | Type::DOUBLE
-            | Type::RATIONAL
-            | Type::SRATIONAL
-            | Type::IFD8 => 8,
-        }
-    }
-}
-
 tags! {
 /// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
 /// for reference.

--- a/src/tiff/tags.rs
+++ b/src/tiff/tags.rs
@@ -175,6 +175,22 @@ pub enum Type(u16) {
 }
 }
 
+impl Type {
+    pub const fn size(&self) -> u64 {
+        match self {
+            Type::BYTE | Type::SBYTE | Type::ASCII | Type::UNDEFINED => 1,
+            Type::SHORT | Type::SSHORT => 2,
+            Type::LONG | Type::SLONG | Type::FLOAT | Type::IFD => 4,
+            Type::LONG8
+            | Type::SLONG8
+            | Type::DOUBLE
+            | Type::RATIONAL
+            | Type::SRATIONAL
+            | Type::IFD8 => 8,
+        }
+    }
+}
+
 tags! {
 /// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
 /// for reference.


### PR DESCRIPTION
Read tags from a buffer which is fetched in its entirety in stead of reading them value-by-value. This allows any middleware to be a bit smart about caching outside of the prefetch range. Also it simplifies logic in `read_tag_value`.


This same idea could also be used for pre-fetchin/reading IFDs themselves from the point the count is known. That _does_ change things a tiny little more, so is its own PR