### PR TITLE
Read tag data in its entirety from AsyncFileReader. 

### DIFF
--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -867,7 +867,7 @@ async fn read_tag_value(
     count: u64,
     bigtiff: bool,
 ) -> AsyncTiffResult<Value> {
-    // Case 1: there are no values so we can return immediately.
+    // Case 0: there are no values so we can return immediately.
     if count == 0 {
         return Ok(Value::List(vec![]));
     }
@@ -910,7 +910,8 @@ async fn read_tag_value(
             .reader();
         EndianAwareReader::new(reader, cursor.endianness())
     };
-    // Case 2: there is one value.
+
+    // Case 1: there is one value.
     if count == 1 {
         return Ok(match tag_type {
             Type::LONG8 => Value::UnsignedBig(data.read_u64()?),
@@ -938,6 +939,7 @@ async fn read_tag_value(
         });
     }
 
+    // Case 2: there is more than one value
     match tag_type {
         Type::BYTE | Type::UNDEFINED => {
             let mut v = Vec::with_capacity(count as _);
@@ -949,7 +951,7 @@ async fn read_tag_value(
         Type::SBYTE => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
-                v.push(Value::SignedByte(data.read_i8()?));
+                v.push(Value::Signed(data.read_i8()? as i32));
             }
             Ok(Value::List(v))
         }

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -887,9 +887,9 @@ async fn read_tag_value(
         // value fits in offset field
         let res = cursor.read(value_byte_length).await?;
         if bigtiff {
-            cursor.advance(8-value_byte_length);
+            cursor.advance(8 - value_byte_length);
         } else {
-            cursor.advance(4-value_byte_length);
+            cursor.advance(4 - value_byte_length);
         }
         res
     } else {
@@ -899,7 +899,11 @@ async fn read_tag_value(
         } else {
             cursor.read_u32().await?.into()
         };
-        let reader = cursor.reader().get_bytes(offset..offset+value_byte_length).await?.reader();
+        let reader = cursor
+            .reader()
+            .get_bytes(offset..offset + value_byte_length)
+            .await?
+            .reader();
         EndianAwareReader::new(reader, cursor.endianness())
         // cursor.seek(offset);
         // cursor.read(value_byte_length).await?
@@ -934,18 +938,18 @@ async fn read_tag_value(
 
     match tag_type {
         Type::BYTE | Type::UNDEFINED => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Byte(data.read_u8()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SBYTE => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SignedByte(data.read_i8()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::ASCII => {
             let mut buf = vec![0; count as usize];
@@ -954,95 +958,95 @@ async fn read_tag_value(
                 let v = std::str::from_utf8(&buf)
                     .map_err(|err| AsyncTiffError::General(err.to_string()))?;
                 let v = v.trim_matches(char::from(0));
-                return Ok(Value::Ascii(v.into()));
+                Ok(Value::Ascii(v.into()))
             } else {
                 panic!("Invalid tag");
                 // return Err(TiffError::FormatError(TiffFormatError::InvalidTag));
             }
         }
         Type::SHORT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Short(data.read_u16()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SSHORT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Signed(i32::from(data.read_i16()?)));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::LONG => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Unsigned(data.read_u32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SLONG => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Signed(data.read_i32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::FLOAT => {
-            let mut v = Vec::new();
+            let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Float(data.read_f32()?));
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::DOUBLE => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Double(data.read_f64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::RATIONAL => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Rational(data.read_u32()?, data.read_u32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SRATIONAL => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SRational(data.read_i32()?, data.read_i32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::LONG8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::UnsignedBig(data.read_u64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::SLONG8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::SignedBig(data.read_i64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::IFD => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::Ifd(data.read_u32()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
         Type::IFD8 => {
             let mut v = Vec::with_capacity(count as _);
             for _ in 0..count {
                 v.push(Value::IfdBig(data.read_u64()?))
             }
-            return Ok(Value::List(v));
+            Ok(Value::List(v))
         }
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -351,31 +351,37 @@ impl AsyncCursor {
     }
 
     /// Read a u8 from the cursor, advancing the internal state by 1 byte.
+    #[allow(dead_code)]
     pub(crate) async fn read_u8(&mut self) -> AsyncTiffResult<u8> {
         self.read(1).await?.read_u8()
     }
 
     /// Read a i8 from the cursor, advancing the internal state by 1 byte.
+    #[allow(dead_code)]
     pub(crate) async fn read_i8(&mut self) -> AsyncTiffResult<i8> {
         self.read(1).await?.read_i8()
     }
 
     /// Read a u16 from the cursor, advancing the internal state by 2 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_u16(&mut self) -> AsyncTiffResult<u16> {
         self.read(2).await?.read_u16()
     }
 
     /// Read a i16 from the cursor, advancing the internal state by 2 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i16(&mut self) -> AsyncTiffResult<i16> {
         self.read(2).await?.read_i16()
     }
 
     /// Read a u32 from the cursor, advancing the internal state by 4 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_u32(&mut self) -> AsyncTiffResult<u32> {
         self.read(4).await?.read_u32()
     }
 
     /// Read a i32 from the cursor, advancing the internal state by 4 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i32(&mut self) -> AsyncTiffResult<i32> {
         self.read(4).await?.read_i32()
     }
@@ -386,24 +392,25 @@ impl AsyncCursor {
     }
 
     /// Read a i64 from the cursor, advancing the internal state by 8 bytes.
+    #[allow(dead_code)]
     pub(crate) async fn read_i64(&mut self) -> AsyncTiffResult<i64> {
         self.read(8).await?.read_i64()
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn read_f32(&mut self) -> AsyncTiffResult<f32> {
         self.read(4).await?.read_f32()
     }
 
+    #[allow(dead_code)]
     pub(crate) async fn read_f64(&mut self) -> AsyncTiffResult<f64> {
         self.read(8).await?.read_f64()
     }
 
-    #[allow(dead_code)]
     pub(crate) fn reader(&self) -> &Arc<dyn AsyncFileReader> {
         &self.reader
     }
 
-    #[allow(dead_code)]
     pub(crate) fn endianness(&self) -> Endianness {
         self.endianness
     }
@@ -417,6 +424,7 @@ impl AsyncCursor {
         self.offset = offset;
     }
 
+    #[allow(dead_code)]
     pub(crate) fn position(&self) -> u64 {
         self.offset
     }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -428,6 +428,9 @@ pub(crate) struct EndianAwareReader {
 }
 
 impl EndianAwareReader {
+    pub(crate) fn new(reader: Reader<Bytes>, endianness: Endianness) -> Self {
+        Self { reader, endianness }
+    }
     /// Read a u8 from the cursor, advancing the internal state by 1 byte.
     pub(crate) fn read_u8(&mut self) -> AsyncTiffResult<u8> {
         Ok(self.reader.read_u8()?)

--- a/src/tiff/tags.rs
+++ b/src/tiff/tags.rs
@@ -175,22 +175,6 @@ pub enum Type(u16) {
 }
 }
 
-impl Type {
-    pub const fn size(&self) -> u64 {
-        match self {
-            Type::BYTE | Type::SBYTE | Type::ASCII | Type::UNDEFINED => 1,
-            Type::SHORT | Type::SSHORT => 2,
-            Type::LONG | Type::SLONG | Type::FLOAT | Type::IFD => 4,
-            Type::LONG8
-            | Type::SLONG8
-            | Type::DOUBLE
-            | Type::RATIONAL
-            | Type::SRATIONAL
-            | Type::IFD8 => 8,
-        }
-    }
-}
-
 tags! {
 /// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
 /// for reference.

--- a/src/tiff/tags.rs
+++ b/src/tiff/tags.rs
@@ -175,6 +175,22 @@ pub enum Type(u16) {
 }
 }
 
+impl Type {
+    pub const fn size(&self) -> u64 {
+        match self {
+            Type::BYTE | Type::SBYTE | Type::ASCII | Type::UNDEFINED => 1,
+            Type::SHORT | Type::SSHORT => 2,
+            Type::LONG | Type::SLONG | Type::FLOAT | Type::IFD => 4,
+            Type::LONG8
+            | Type::SLONG8
+            | Type::DOUBLE
+            | Type::RATIONAL
+            | Type::SRATIONAL
+            | Type::IFD8 => 8,
+        }
+    }
+}
+
 tags! {
 /// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
 /// for reference.


### PR DESCRIPTION
Why was #76 closed 👀? 

Closes #70 

This PR allows a caching middleware to directly estimate the remaining `TileOffsets` and `TileByteCounts` arrays from the byte size of `TileOffsets0`, which is in #74 as a proof-of-concept.

- without this: first out-of-cache request will be a single u64 byte range
- with this: first out-of-cache request will be the full `TileOffsets0` array

~~A middleware _could_ do exponential cache growing, just like a `Vec`, but if a good estimate (`2*range_len+4*range_len.isqrt()`) of size can be made, `Vec::with_capacity(good_estimate)` is better [derivation.pdf](https://github.com/user-attachments/files/19487170/main.pdf).~~

**EDIT**: Actually, an exponential prefetch (exponent 2) will work quite well with this, since the byte size of all ifds ~>= `4*TileOffsets0.isqrt()`[^1]

also Cleans up tag loading logic and cursor handling.

[^1]: The estimate of $2b_{offset0}+4\sqrt(b_{offset0}$ is only based on the assumption that we are dealing with a square unmasked bigtiff cog. smalltiff adds a $\frac{4}{3}$ factor, masks a $2$ factor and square-ness only works on the $\sqrt{}$ factor, which is small in comparison. 
