### PR TITLE
Exponential overflow header buffer

### DIFF
--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -37,7 +37,7 @@ impl AsRef<[ImageFileDirectory]> for ImageFileDirectories {
 
 impl ImageFileDirectories {
     pub(crate) async fn open(
-        cursor: &mut AsyncCursor,
+        cursor: &mut AsyncCursor<'_>,
         ifd_offset: u64,
         bigtiff: bool,
     ) -> AsyncTiffResult<Self> {
@@ -184,7 +184,7 @@ pub struct ImageFileDirectory {
 impl ImageFileDirectory {
     /// Read and parse the IFD starting at the given file offset
     async fn read(
-        cursor: &mut AsyncCursor,
+        cursor: &mut AsyncCursor<'_>,
         ifd_start: u64,
         bigtiff: bool,
     ) -> AsyncTiffResult<Self> {
@@ -774,7 +774,7 @@ impl ImageFileDirectory {
         &self,
         x: usize,
         y: usize,
-        reader: &dyn AsyncFileReader,
+        reader: &mut dyn AsyncFileReader,
     ) -> AsyncTiffResult<Tile> {
         let range = self
             .get_tile_byte_range(x, y)
@@ -795,7 +795,7 @@ impl ImageFileDirectory {
         &self,
         x: &[usize],
         y: &[usize],
-        reader: &dyn AsyncFileReader,
+        reader: &mut dyn AsyncFileReader,
     ) -> AsyncTiffResult<Vec<Tile>> {
         assert_eq!(x.len(), y.len(), "x and y should have same len");
 
@@ -838,7 +838,7 @@ impl ImageFileDirectory {
 }
 
 /// Read a single tag from the cursor
-async fn read_tag(cursor: &mut AsyncCursor, bigtiff: bool) -> AsyncTiffResult<(Tag, Value)> {
+async fn read_tag(cursor: &mut AsyncCursor<'_>, bigtiff: bool) -> AsyncTiffResult<(Tag, Value)> {
     let start_cursor_position = cursor.position();
 
     let tag_name = Tag::from_u16_exhaustive(cursor.read_u16().await?);
@@ -868,7 +868,7 @@ async fn read_tag(cursor: &mut AsyncCursor, bigtiff: bool) -> AsyncTiffResult<(T
 // This is derived from the upstream tiff crate:
 // https://github.com/image-rs/image-tiff/blob/6dc7a266d30291db1e706c8133357931f9e2a053/src/decoder/ifd.rs#L369-L639
 async fn read_tag_value(
-    cursor: &mut AsyncCursor,
+    cursor: &mut AsyncCursor<'_>,
     tag_type: Type,
     count: u64,
     bigtiff: bool,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -591,7 +591,7 @@ mod test {
         let reader = TestAsyncFileReader {
             buffer: Bytes::from_static(underlying_buffer),
         };
-        let mut prefetch_reader = PrefetchReader::new(Box::new(reader), 5, 1.1).await.unwrap();
+        let mut prefetch_reader = PrefetchReader::new(Box::new(reader), 5, 1.).await.unwrap();
 
         // Cached
         assert_eq!(
@@ -642,5 +642,10 @@ mod test {
                 .as_ref(),
             underlying_buffer
         );
+
+        // Assert underlying buffers were cached
+        assert_eq!(prefetch_reader.buffers[0].as_ref(), b"abcde");
+        assert_eq!(prefetch_reader.buffers[1].as_ref(), b"fghij");
+        assert_eq!(prefetch_reader.buffers[2].as_ref(), b"klmno");
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -591,7 +591,7 @@ mod test {
         let reader = TestAsyncFileReader {
             buffer: Bytes::from_static(underlying_buffer),
         };
-        let mut prefetch_reader = PrefetchReader::new(Box::new(reader), 5, 1.5).await.unwrap();
+        let mut prefetch_reader = PrefetchReader::new(Box::new(reader), 5, 1.1).await.unwrap();
 
         // Cached
         assert_eq!(
@@ -631,6 +631,16 @@ mod test {
                 .unwrap()
                 .as_ref(),
             b"abcdefghij"
+        );
+
+        // Cached
+        assert_eq!(
+            prefetch_reader
+                .get_metadata_bytes(0..15)
+                .await
+                .unwrap()
+                .as_ref(),
+            underlying_buffer
         );
     }
 }

--- a/tests/image_tiff/util.rs
+++ b/tests/image_tiff/util.rs
@@ -10,6 +10,6 @@ const TEST_IMAGE_DIR: &str = "tests/image_tiff/images/";
 pub(crate) async fn open_tiff(filename: &str) -> TIFF {
     let store = Arc::new(LocalFileSystem::new_with_prefix(current_dir().unwrap()).unwrap());
     let path = format!("{TEST_IMAGE_DIR}/{filename}");
-    let reader = Arc::new(ObjectReader::new(store.clone(), path.as_str().into()));
-    TIFF::try_open(reader).await.unwrap()
+    let mut reader = Box::new(ObjectReader::new(store.clone(), path.as_str().into()));
+    TIFF::try_open(reader.as_mut()).await.unwrap()
 }


### PR DESCRIPTION
### Changes 

- Updates `AsyncFileReader` to use `&mut self` instead of `&self` on the trait methods. This is necessary so that the buffer can be **mutated** when fetching the overflow, while also adding it to the cached buffers
- Use `Box` instead of `Arc` in reader code, now that we need mutability of the reader.
- Updates the tokio integration to implement `AsyncFileReader` directly on anything that implements `AsyncRead` and `AsyncSeek`. We don't need a wrapper object now that we use `&mut self` ourselves.
- Add test to verify overflow handling

This PR is not made on top of #82, but I think some mix of this and #82 makes sense.