### PR TITLE
added predictors

### DIFF
--- a/src/cog.rs
+++ b/src/cog.rs
@@ -25,6 +25,7 @@ mod test {
 
     use crate::decoder::DecoderRegistry;
     use crate::metadata::{PrefetchBuffer, TiffMetadataReader};
+    use crate::predictor::RevPredictorRegistry;
     use crate::reader::{AsyncFileReader, ObjectReader};
 
     use super::*;
@@ -52,8 +53,9 @@ mod test {
 
         let ifd = &tiff.ifds[1];
         let decoder_registry = DecoderRegistry::default();
+        let predictor_registry = RevPredictorRegistry::default();
         let tile = ifd.fetch_tile(0, 0, reader.as_ref()).await.unwrap();
-        let tile = tile.decode(&decoder_registry).unwrap();
+        let tile = tile.decode(&decoder_registry, &predictor_registry).unwrap();
         std::fs::write("img.buf", tile).unwrap();
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,10 @@ pub enum AsyncTiffError {
     #[error("General error: {0}")]
     General(String),
 
+    /// Tile index error
+    #[error("Tile index out of bounds: {0}, {1}")]
+    TileIndexError(u32, u32),
+
     /// IO Error.
     #[error(transparent)]
     IOError(#[from] std::io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod geo;
 mod ifd;
 pub mod metadata;
+pub mod predictor;
 pub mod tiff;
 mod tile;
 

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -226,7 +226,7 @@ impl ImageFileDirectoryReader {
             let (tag, value) = self.read_tag(fetch, tag_idx).await?;
             tags.insert(tag, value);
         }
-        ImageFileDirectory::from_tags(tags)
+        ImageFileDirectory::from_tags(tags, self.endianness)
     }
 
     /// Finish this reader, reading the byte offset of the next IFD
@@ -623,10 +623,13 @@ async fn read_tag_value<F: MetadataFetch>(
 
 #[cfg(test)]
 mod test {
+    use crate::{
+        metadata::{reader::read_tag, MetadataFetch},
+        reader::Endianness,
+        tiff::{tags::Tag, Value},
+    };
     use bytes::Bytes;
     use futures::FutureExt;
-
-    use super::*;
 
     impl MetadataFetch for Bytes {
         fn fetch(

--- a/src/predictor.rs
+++ b/src/predictor.rs
@@ -1,0 +1,507 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use byteorder::NativeEndian;
+use bytes::{Bytes, BytesMut};
+// use tiff::decoder::DecodingResult;
+
+use crate::{
+    error::AsyncTiffResult, reader::Endianness, tiff::tags::Predictor, tile::PredictorInfo,
+};
+
+/// A registry for reverse predictors
+///
+/// Reverse predictors, because they perform the inverse (decoding) operation of prediction
+///
+///
+///
+pub struct RevPredictorRegistry(HashMap<Predictor, Box<dyn RevPredictor>>);
+
+impl RevPredictorRegistry {
+    /// create a new predictor registry with no predictors registered
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+}
+
+impl AsRef<HashMap<Predictor, Box<dyn RevPredictor>>> for RevPredictorRegistry {
+    fn as_ref(&self) -> &HashMap<Predictor, Box<dyn RevPredictor>> {
+        &self.0
+    }
+}
+
+impl Default for RevPredictorRegistry {
+    fn default() -> Self {
+        let mut hmap = HashMap::new();
+        hmap.insert(Predictor::None, Box::new(NoPredictor) as _);
+        hmap.insert(Predictor::Horizontal, Box::new(RevHorizontalPredictor) as _);
+        hmap.insert(
+            Predictor::FloatingPoint,
+            Box::new(RevFloatingPointPredictor) as _,
+        );
+        Self(hmap)
+    }
+}
+
+/// Trait for reverse predictors to implement
+///
+///
+pub trait RevPredictor: Debug + Send + Sync {
+    /// reverse predict the decompressed bytes and fix endianness on the output
+    ///
+    ///
+    fn rev_predict_fix_endianness(
+        &self,
+        buffer: Bytes,
+        predictor_info: &PredictorInfo,
+        tile_x: u32,
+        tile_y: u32,
+    ) -> AsyncTiffResult<Bytes>; // having this Bytes will give alignment issues later on
+}
+
+/// no predictor
+#[derive(Debug)]
+pub struct NoPredictor;
+
+impl RevPredictor for NoPredictor {
+    fn rev_predict_fix_endianness(
+        &self,
+        buffer: Bytes,
+        predictor_info: &PredictorInfo,
+        _: u32,
+        _: u32,
+    ) -> AsyncTiffResult<Bytes> {
+        let mut res = BytesMut::from(buffer);
+        fix_endianness(
+            &mut res[..],
+            predictor_info.endianness,
+            predictor_info.bits_per_sample[0],
+        );
+        Ok(res.into())
+    }
+}
+
+/// reverse horizontal predictor
+#[derive(Debug)]
+pub struct RevHorizontalPredictor;
+
+impl RevPredictor for RevHorizontalPredictor {
+    fn rev_predict_fix_endianness(
+        &self,
+        buffer: Bytes,
+        predictor_info: &PredictorInfo,
+        tile_x: u32,
+        _: u32,
+    ) -> AsyncTiffResult<Bytes> {
+        let output_row_stride = predictor_info.output_row_stride(tile_x)?;
+        let samples = predictor_info.samples_per_pixel as usize;
+        let bit_depth = predictor_info.bits_per_sample[0];
+
+        let mut res = BytesMut::from(buffer);
+        for buf in res.chunks_mut(output_row_stride) {
+            // this is rev_hpredict_nsamp from image-tiff
+            rev_hpredict_nsamp(buf, bit_depth, samples);
+            // end rev_hpredict_nsamp
+        }
+        fix_endianness(&mut res[..], predictor_info.endianness, bit_depth);
+        Ok(res.into())
+    }
+}
+
+/// Reverse predictor convenienve function for horizontal differencing
+///
+/// From image-tiff
+pub fn rev_hpredict_nsamp(buf: &mut [u8], bit_depth: u16, samples: usize) {
+    match bit_depth {
+        0..=8 => {
+            for i in samples..buf.len() {
+                buf[i] = buf[i].wrapping_add(buf[i - samples]);
+            }
+        }
+        9..=16 => {
+            for i in (samples * 2..buf.len()).step_by(2) {
+                let v = u16::from_ne_bytes(buf[i..][..2].try_into().unwrap());
+                let p = u16::from_ne_bytes(buf[i - 2 * samples..][..2].try_into().unwrap());
+                buf[i..][..2].copy_from_slice(&(v.wrapping_add(p)).to_ne_bytes());
+            }
+        }
+        17..=32 => {
+            for i in (samples * 4..buf.len()).step_by(4) {
+                let v = u32::from_ne_bytes(buf[i..][..4].try_into().unwrap());
+                let p = u32::from_ne_bytes(buf[i - 4 * samples..][..4].try_into().unwrap());
+                buf[i..][..4].copy_from_slice(&(v.wrapping_add(p)).to_ne_bytes());
+            }
+        }
+        33..=64 => {
+            for i in (samples * 8..buf.len()).step_by(8) {
+                let v = u64::from_ne_bytes(buf[i..][..8].try_into().unwrap());
+                let p = u64::from_ne_bytes(buf[i - 8 * samples..][..8].try_into().unwrap());
+                buf[i..][..8].copy_from_slice(&(v.wrapping_add(p)).to_ne_bytes());
+            }
+        }
+        _ => {
+            unreachable!("Caller should have validated arguments. Please file a bug.")
+        }
+    }
+}
+
+/// Fix endianness. If `byte_order` matches the host, then conversion is a no-op.
+///
+/// from image-tiff
+pub fn fix_endianness(buf: &mut [u8], byte_order: Endianness, bit_depth: u16) {
+    match byte_order {
+        Endianness::LittleEndian => match bit_depth {
+            0..=8 => {}
+            9..=16 => buf.chunks_exact_mut(2).for_each(|v| {
+                v.copy_from_slice(&u16::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+            17..=32 => buf.chunks_exact_mut(4).for_each(|v| {
+                v.copy_from_slice(&u32::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+            _ => buf.chunks_exact_mut(8).for_each(|v| {
+                v.copy_from_slice(&u64::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+        },
+        Endianness::BigEndian => match bit_depth {
+            0..=8 => {}
+            9..=16 => buf.chunks_exact_mut(2).for_each(|v| {
+                v.copy_from_slice(&u16::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+            17..=32 => buf.chunks_exact_mut(4).for_each(|v| {
+                v.copy_from_slice(&u32::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+            _ => buf.chunks_exact_mut(8).for_each(|v| {
+                v.copy_from_slice(&u64::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
+            }),
+        },
+    };
+}
+
+/// Floating point predictor
+#[derive(Debug)]
+pub struct RevFloatingPointPredictor;
+
+impl RevPredictor for RevFloatingPointPredictor {
+    fn rev_predict_fix_endianness(
+        &self,
+        buffer: Bytes,
+        predictor_info: &PredictorInfo,
+        tile_x: u32,
+        tile_y: u32,
+    ) -> AsyncTiffResult<Bytes> {
+        let output_row_stride = predictor_info.output_row_stride(tile_x)?;
+        let mut res: BytesMut = BytesMut::zeroed(
+            output_row_stride * predictor_info.chunk_height_pixels(tile_y)? as usize,
+        );
+        let bit_depth = predictor_info.bits_per_sample[0] as usize;
+        if predictor_info.chunk_width_pixels(tile_x)? == predictor_info.chunk_width {
+            // no special padding handling
+            let mut input = BytesMut::from(buffer);
+            for (in_buf, out_buf) in input
+                .chunks_mut(output_row_stride)
+                .zip(res.chunks_mut(output_row_stride))
+            {
+                match bit_depth {
+                    16 => rev_predict_f16(in_buf, out_buf, predictor_info.samples_per_pixel as _),
+                    32 => rev_predict_f32(in_buf, out_buf, predictor_info.samples_per_pixel as _),
+                    64 => rev_predict_f64(in_buf, out_buf, predictor_info.samples_per_pixel as _),
+                    _ => panic!("thou shalt not predict with float16"),
+                }
+            }
+        } else {
+            // specially handle padding bytes
+            // create a buffer for the full width
+            let mut input = BytesMut::from(buffer);
+
+            let input_row_stride =
+                predictor_info.chunk_width as usize * predictor_info.bits_per_pixel() / 8;
+            for (in_buf, out_buf) in input
+                .chunks_mut(input_row_stride)
+                .zip(res.chunks_mut(output_row_stride))
+            {
+                let mut out_row = BytesMut::zeroed(input_row_stride);
+                match bit_depth {
+                    16 => rev_predict_f16(in_buf, out_buf, predictor_info.samples_per_pixel as _),
+                    32 => {
+                        rev_predict_f32(in_buf, &mut out_row, predictor_info.samples_per_pixel as _)
+                    }
+                    64 => {
+                        rev_predict_f64(in_buf, &mut out_row, predictor_info.samples_per_pixel as _)
+                    }
+                    _ => panic!("thou shalt not predict f16"),
+                }
+                out_buf.copy_from_slice(&out_row[..output_row_stride]);
+            }
+        }
+        Ok(res.into())
+    }
+}
+
+/// Reverse floating point prediction
+///
+/// floating point prediction first shuffles the bytes and then uses horizontal
+/// differencing  
+/// also performs byte-order conversion if needed.
+///
+pub fn rev_predict_f16(input: &mut [u8], output: &mut [u8], samples: usize) {
+    // reverse horizontal differencing
+    for i in samples..input.len() {
+        input[i] = input[i].wrapping_add(input[i - samples]);
+    }
+    // reverse byte shuffle and fix endianness
+    for (i, chunk) in output.chunks_mut(2).enumerate() {
+        chunk.copy_from_slice(&u16::to_ne_bytes(
+            // convert to native-endian
+            // preserve original byte-order
+            u16::from_be_bytes([input[i], input[input.len() / 2 + i]]),
+        ));
+    }
+}
+
+/// Reverse floating point prediction
+///
+/// floating point prediction first shuffles the bytes and then uses horizontal
+/// differencing  
+/// also performs byte-order conversion if needed.
+///
+pub fn rev_predict_f32(input: &mut [u8], output: &mut [u8], samples: usize) {
+    // reverse horizontal differencing
+    for i in samples..input.len() {
+        input[i] = input[i].wrapping_add(input[i - samples]);
+    }
+    println!("output: {output:?}, {:?}", output.len());
+    // reverse byte shuffle and fix endianness
+    for (i, chunk) in output.chunks_mut(4).enumerate() {
+        println!("i:{i:?}");
+        chunk.copy_from_slice(&u32::to_ne_bytes(
+            // convert to native-endian
+            // preserve original byte-order
+            u32::from_be_bytes([
+                input[i],
+                input[input.len() / 4 + i],
+                input[input.len() / 4 * 2 + i],
+                input[input.len() / 4 * 3 + i],
+            ]),
+        ));
+    }
+}
+
+/// Reverse floating point prediction
+///
+/// floating point prediction first shuffles the bytes and then uses horizontal
+/// differencing  
+/// Also fixes byte order if needed (tiff's->native)
+pub fn rev_predict_f64(input: &mut [u8], output: &mut [u8], samples: usize) {
+    for i in samples..input.len() {
+        input[i] = input[i].wrapping_add(input[i - samples]);
+    }
+
+    for (i, chunk) in output.chunks_mut(8).enumerate() {
+        chunk.copy_from_slice(&u64::to_ne_bytes(u64::from_be_bytes([
+            input[i],
+            input[input.len() / 8 + i],
+            input[input.len() / 8 * 2 + i],
+            input[input.len() / 8 * 3 + i],
+            input[input.len() / 8 * 4 + i],
+            input[input.len() / 8 * 5 + i],
+            input[input.len() / 8 * 6 + i],
+            input[input.len() / 8 * 7 + i],
+        ])));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+
+    use crate::{
+        predictor::RevFloatingPointPredictor,
+        reader::Endianness,
+        tiff::tags::{PlanarConfiguration, SampleFormat},
+        tile::PredictorInfo,
+    };
+
+    use super::{NoPredictor, RevHorizontalPredictor, RevPredictor};
+
+    const PRED_INFO: PredictorInfo = PredictorInfo {
+        endianness: Endianness::LittleEndian,
+        image_width: 15,
+        image_height: 15,
+        chunk_width: 8,
+        chunk_height: 8,
+        bits_per_sample: &[8],
+        samples_per_pixel: 1,
+        sample_format: &[SampleFormat::Uint],
+        planar_configuration: crate::tiff::tags::PlanarConfiguration::Chunky,
+    };
+    #[rustfmt::skip]
+    const RES: [u8;64] = [
+        0,1,2,3, 4,5,6,7,
+        1,0,1,2, 3,4,5,6,
+        2,1,0,1, 2,3,4,5,
+        3,2,1,0, 1,2,3,4,
+
+        4,3,2,1, 0,1,2,3,
+        5,4,3,2, 1,0,1,2,
+        6,5,4,3, 2,1,0,1,
+        7,6,5,4, 3,2,1,0,
+        ];
+    #[rustfmt::skip]
+    const RES_RIGHT: [u8;56] = [
+        0,1,2,3, 4,5,6,
+        1,0,1,2, 3,4,5,
+        2,1,0,1, 2,3,4,
+        3,2,1,0, 1,2,3,
+
+        4,3,2,1, 0,1,2,
+        5,4,3,2, 1,0,1,
+        6,5,4,3, 2,1,0,
+        7,6,5,4, 3,2,1,
+        ];
+    #[rustfmt::skip]
+    const RES_BOT: [u8;56] = [
+        0,1,2,3, 4,5,6,7,
+        1,0,1,2, 3,4,5,6,
+        2,1,0,1, 2,3,4,5,
+        3,2,1,0, 1,2,3,4,
+
+        4,3,2,1, 0,1,2,3,
+        5,4,3,2, 1,0,1,2,
+        6,5,4,3, 2,1,0,1,
+        ];
+    #[rustfmt::skip]
+    const RES_BOT_RIGHT: [u8;49] = [
+        0,1,2,3, 4,5,6,
+        1,0,1,2, 3,4,5,
+        2,1,0,1, 2,3,4,
+        3,2,1,0, 1,2,3,
+
+        4,3,2,1, 0,1,2,
+        5,4,3,2, 1,0,1,
+        6,5,4,3, 2,1,0,
+        ];
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_no_predict() {
+        let p = NoPredictor;
+        let cases = [
+            (0,0, Bytes::from_static(&RES[..]),           Bytes::from_static(&RES[..])          ),
+            (0,1, Bytes::from_static(&RES_BOT[..]),       Bytes::from_static(&RES_BOT[..])      ),
+            (1,0, Bytes::from_static(&RES_RIGHT[..]),     Bytes::from_static(&RES_RIGHT[..])    ),
+            (1,1, Bytes::from_static(&RES_BOT_RIGHT[..]), Bytes::from_static(&RES_BOT_RIGHT[..]))
+        ];
+        for (x,y, input, expected) in cases {
+            assert_eq!(p.rev_predict_fix_endianness(input, &PRED_INFO, x, y).unwrap(), expected);
+        }
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn test_hpredict() {
+        let p = RevHorizontalPredictor;
+        let cases = [
+            (0,0, Bytes::from_static(&[
+                0,  1,  1,  1,   1,  1,  1,  1,
+                1,255,  1,  1,   1,  1,  1,  1,
+                2,255,255,  1,   1,  1,  1,  1,
+                3,255,255,255,   1,  1,  1,  1,
+
+                4,255,255,255, 255,  1,  1,  1,
+                5,255,255,255, 255,255,  1,  1,
+                6,255,255,255, 255,255,255,  1,
+                7,255,255,255, 255,255,255,255,
+            ]), Bytes::from_static(&RES[..])          ),
+            (0,1, Bytes::from_static(&[
+                0,  1,  1,  1,   1,  1,  1,  1,
+                1,255,  1,  1,   1,  1,  1,  1,
+                2,255,255,  1,   1,  1,  1,  1,
+                3,255,255,255,   1,  1,  1,  1,
+
+                4,255,255,255, 255,  1,  1,  1,
+                5,255,255,255, 255,255,  1,  1,
+                6,255,255,255, 255,255,255,  1,
+            ]),       Bytes::from_static(&RES_BOT[..])      ),
+            (1,0, Bytes::from_static(&[
+                0,  1,  1,  1,   1,  1,  1,
+                1,255,  1,  1,   1,  1,  1,
+                2,255,255,  1,   1,  1,  1,
+                3,255,255,255,   1,  1,  1,
+
+                4,255,255,255, 255,  1,  1,
+                5,255,255,255, 255,255,  1,
+                6,255,255,255, 255,255,255,
+                7,255,255,255, 255,255,255,
+            ]),     Bytes::from_static(&RES_RIGHT[..])    ),
+            (1,1, Bytes::from_static(&[
+                0,  1,  1,  1,   1,  1,  1,
+                1,255,  1,  1,   1,  1,  1,
+                2,255,255,  1,   1,  1,  1,
+                3,255,255,255,   1,  1,  1,
+
+                4,255,255,255, 255,  1,  1,
+                5,255,255,255, 255,255,  1,
+                6,255,255,255, 255,255,255,
+            ]), Bytes::from_static(&RES_BOT_RIGHT[..]))
+        ];
+        for (x,y, input, expected) in cases {
+            let res = p.rev_predict_fix_endianness(input.clone(), &PRED_INFO, x, y).unwrap();
+            println!("testing ({x},{y}): {:?}?={:?}", &res[..], &expected[..]);
+            assert_eq!(res, expected);
+
+            // also errors shouldn't crash
+            // p.rev_predict_fix_endianness(input, &PRED_INFO, x+1, y+1).unwrap_err();
+        }
+    }
+
+    // #[rustfmt::skip]
+    #[test]
+    fn test_fpredict_f32() {
+        // let's take this 2-value image
+        let expected: Vec<u8> = [42.0f32, 43.0].iter().flat_map(|f| f.to_le_bytes()).collect();
+        assert_eq!(expected, vec![0x0,0x0,0x28,0x42,0x0,0x0,0x2c,0x42]);
+        let info = PredictorInfo {
+            endianness: Endianness::LittleEndian,
+            image_width: 2,
+            image_height: 2 + 1,
+            chunk_width: 2,
+            chunk_height: 2,
+            bits_per_sample: &[32],
+            samples_per_pixel: 1,
+            sample_format: &[SampleFormat::IEEEFP],
+            planar_configuration: PlanarConfiguration::Chunky,
+        };
+        let input = Bytes::from_static(&[0x42u8, 0, 230, 4, 212, 0, 0, 0]);
+        assert_eq!(
+            RevFloatingPointPredictor
+                .rev_predict_fix_endianness(input, &info, 0, 1)
+                .unwrap(),
+            expected
+        );
+    }
+
+    // #[test]
+    // fn test_fpredict_f64() {
+    //     // let's take this 2-value image
+    //     let expected: Vec<u8> = [42.0f64, 43.0].iter().flat_map(|f| f.to_le_bytes()).collect();
+    //     assert_eq!(expected, vec![0,0,0,0,0,0,69,64,0,0,0,0,0,128,69,64]);
+    //     let info = PredictorInfo {
+    //         endianness: Endianness::LittleEndian,
+    //         image_width: 2,
+    //         image_height: 2 + 1,
+    //         chunk_width: 2,
+    //         chunk_height: 2,
+    //         bits_per_sample: &[64],
+    //         samples_per_pixel: 1,
+    //         sample_format: &[SampleFormat::IEEEFP],
+    //         planar_configuration: PlanarConfiguration::Chunky,
+    //     };
+    //     let input = Bytes::from_static(&[0x42u8, 0, 230, 4, 212, 0, 0, 0]);
+    //     assert_eq!(
+    //         RevFloatingPointPredictor
+    //             .rev_predict_fix_endianness(input, &info, 0, 1)
+    //             .unwrap(),
+    //         expected
+    //     );
+    // }
+}

--- a/src/tiff/error.rs
+++ b/src/tiff/error.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use jpeg::UnsupportedFeature;
 
 use super::ifd::Value;
+use super::tags::Predictor;
 use super::tags::{
     CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag,
 };
@@ -152,6 +153,7 @@ pub enum TiffUnsupportedError {
     UnknownInterpretation,
     UnknownCompressionMethod,
     UnsupportedCompressionMethod(CompressionMethod),
+    UnsupportedPredictor(Predictor),
     UnsupportedSampleDepth(u8),
     UnsupportedSampleFormat(Vec<SampleFormat>),
     // UnsupportedColorType(ColorType),
@@ -192,6 +194,9 @@ impl fmt::Display for TiffUnsupportedError {
             UnknownCompressionMethod => write!(fmt, "Unknown compression method."),
             UnsupportedCompressionMethod(method) => {
                 write!(fmt, "Compression method {:?} is unsupported", method)
+            }
+            UnsupportedPredictor(p) => {
+                write!(fmt, "Predictor {p:?} is not supported")
             }
             UnsupportedSampleDepth(samples) => {
                 write!(fmt, "{} samples per pixel is unsupported.", samples)


### PR DESCRIPTION
Added predictors and rudimentary tests.

Since floating point predictors shuffle horizontal padding into the output, quite a lot more information is needed, so I made a public `PredictorInfo` struct with public methods that give tile/chunk info. 

Some notes:
- Also use a registry structure, so people can swap out their own if they'd want to
- I did put in the possibility for multiple sample formats, which links our lifetime to the tile... I think it'd also be perfectly fine to accept only a single value, but then I think it'd also make sense to reflect that at IFD?
- image-tiff does not support horizontal predictor for floating-point rasters, GDAL _does_. Since here the two layers are decoupled, I didn't put any checks, but just give the user bogus output if they give bogus input.
- output being Bytes, rather than having a `&mut [u8]` function input. The `&mut [u8]` would be preferred by me, because then it can be directly read into a user-provided buffer that has also ensured the alignment of the buffer (e.g. using initializing a `Vec<f32>` buffer and then bytemucking to `&mut [u8]`)