### PR TITLE
Raise FileNotFoundError instead of panic when opening missing files

### DIFF
--- a/python/tests/test_cog.py
+++ b/python/tests/test_cog.py
@@ -1,7 +1,10 @@
 import async_tiff
 from time import time
+
+import pytest
+
 from async_tiff import TIFF
-from async_tiff.store import S3Store
+from async_tiff.store import LocalStore, S3Store
 
 store = S3Store("sentinel-cogs", region="us-west-2", skip_signature=True)
 path = "sentinel-s2-l2a-cogs/12/S/UF/2022/6/S2B_12SUF_20220609_0_L2A/B04.tif"
@@ -25,3 +28,12 @@ gkd.projected_type
 gkd.citation
 
 dir(gkd)
+
+
+async def test_cog_missing_file():
+    """
+    Ensure that a FileNotFoundError is raised when passing in a missing file.
+    """
+    store = LocalStore()
+    with pytest.raises(FileNotFoundError):
+        await TIFF.open(path="imaginary_file.tif", store=store)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Avoid panic when non-existent file is passed into `TIFF.open`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Replace `.unwrap()` with `.map_err(|err| PyFileNotFoundError::new_err(err.to_string()))?`
- Add unit test to ensure `FileNotFoundError` is raised for missing files

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `cd python && uv run pytest --verbose` locally (preferrably on top of #92)

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Fixes #90
