### PR TITLE
Read SignedByte as i8, handle casting of Byte (u8) into unsigned types

### DIFF
--- a/src/tiff/ifd.rs
+++ b/src/tiff/ifd.rs
@@ -52,6 +52,7 @@ impl Value {
 
     pub fn into_u16(self) -> TiffResult<u16> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val),
             Unsigned(val) => Ok(u16::try_from(val)?),
             UnsignedBig(val) => Ok(u16::try_from(val)?),
@@ -73,6 +74,7 @@ impl Value {
 
     pub fn into_u32(self) -> TiffResult<u32> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val.into()),
             Unsigned(val) => Ok(val),
             UnsignedBig(val) => Ok(u32::try_from(val)?),
@@ -98,6 +100,7 @@ impl Value {
 
     pub fn into_u64(self) -> TiffResult<u64> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val.into()),
             Unsigned(val) => Ok(val.into()),
             UnsignedBig(val) => Ok(val),
@@ -157,6 +160,7 @@ impl Value {
                 }
                 Ok(new_vec)
             }
+            Byte(val) => Ok(vec![val.into()]),
             Short(val) => Ok(vec![val.into()]),
             Unsigned(val) => Ok(vec![val]),
             UnsignedBig(val) => Ok(vec![u32::try_from(val)?]),
@@ -183,10 +187,7 @@ impl Value {
                 Ok(new_vec)
             }
             Byte(val) => Ok(vec![val]),
-
-            val => Err(TiffError::FormatError(
-                TiffFormatError::UnsignedIntegerExpected(val),
-            )),
+            val => Err(TiffError::FormatError(TiffFormatError::ByteExpected(val))),
         }
     }
 
@@ -199,6 +200,7 @@ impl Value {
                 }
                 Ok(new_vec)
             }
+            Byte(val) => Ok(vec![val.into()]),
             Short(val) => Ok(vec![val]),
             val => Err(TiffError::FormatError(TiffFormatError::ShortExpected(val))),
         }


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Ensuring SignedByte -> i8 and Byte -> u8

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Raise `TiffFormatError::ByteExpected` in into_u8_vec
- Support casting Byte to other unsigned types via the `into_u16`, `into_u64`, `into_u16_vec`, `into_u32_vec` and `into_u64_vec` methods.
- Correctly cast `Type::SBYTE` as i8 values

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `cargo test` locally

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- Port over from https://github.com/image-rs/image-tiff/pull/236
