### PR TITLE
Raise TypeError instead of panic on doing fetch_tile from striped TIFFs

### DIFF
--- a/python/tests/test_exceptions.py
+++ b/python/tests/test_exceptions.py
@@ -1,0 +1,22 @@
+"""
+Unit tests to ensure that proper errors are raised instead of a panic.
+"""
+
+import pytest
+from async_tiff.store import HTTPStore
+
+from async_tiff import TIFF
+
+
+async def test_raise_typeerror_fetch_tile_striped_tiff():
+    """
+    Ensure that a TypeError is raised when trying to fetch a tile from a striped TIFF.
+    """
+    store = HTTPStore(url="https://github.com/")
+    path = "OSGeo/gdal/raw/refs/tags/v3.11.0/autotest/gdrivers/data/gtiff/int8.tif"
+
+    tiff = await TIFF.open(path=path, store=store)
+    assert len(tiff.ifds) >= 1
+
+    with pytest.raises(TypeError):
+        await tiff.fetch_tile(0, 0, 0)


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Avoid panic when running `.fetch_tile()` on a striped TIFF (that does not have tiles).

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Replace `.unwrap()` with `.map_err(|err| PyTypeError::new_err(err.to_string()))`
- Add unit test to ensure `TypeError` is raised when calling `.fetch_tile()` on a striped TIFF

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `cd python && uv run pytest --verbose` or look at CI

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Closes #98
