### PR TITLE
Test opening single-channel OME-TIFF file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.43.0", optional = true, default-features = false, feature
 weezl = "0.1.0"
 
 [dev-dependencies]
-object_store = "0.12"
+object_store = { version = "0.12", features = ["http"] }
 tiff = "0.9.1"
 tokio = { version = "1.9", features = [
     "macros",

--- a/tests/ome_tiff.rs
+++ b/tests/ome_tiff.rs
@@ -1,0 +1,21 @@
+/// Integration tests on OME-TIFF files.
+use async_tiff::tiff::tags::PhotometricInterpretation;
+
+mod util;
+
+#[tokio::test]
+async fn test_ome_tiff_single_channel() {
+    let tiff =
+        util::open_remote_tiff("https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/bioformats-artificial/single-channel.ome.tif").await;
+
+    assert_eq!(tiff.ifds().len(), 1);
+    let ifd = &tiff.ifds()[0];
+
+    assert_eq!(
+        ifd.photometric_interpretation(),
+        PhotometricInterpretation::BlackIsZero
+    );
+    assert_eq!(ifd.image_description(), Some("<?xml version=\"1.0\" encoding=\"UTF-8\"?><!-- Warning: this comment is an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/. --><OME xmlns=\"http://www.openmicroscopy.org/Schemas/OME/2016-06\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" Creator=\"OME Bio-Formats 5.2.2\" UUID=\"urn:uuid:2bc2aa39-30d2-44ee-8399-c513492dd5de\" xsi:schemaLocation=\"http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd\"><Image ID=\"Image:0\" Name=\"single-channel.ome.tif\"><Pixels BigEndian=\"true\" DimensionOrder=\"XYZCT\" ID=\"Pixels:0\" SizeC=\"1\" SizeT=\"1\" SizeX=\"439\" SizeY=\"167\" SizeZ=\"1\" Type=\"int8\"><Channel ID=\"Channel:0:0\" SamplesPerPixel=\"1\"><LightPath/></Channel><TiffData FirstC=\"0\" FirstT=\"0\" FirstZ=\"0\" IFD=\"0\" PlaneCount=\"1\"><UUID FileName=\"single-channel.ome.tif\">urn:uuid:2bc2aa39-30d2-44ee-8399-c513492dd5de</UUID></TiffData></Pixels></Image></OME>"));
+
+    assert!(ifd.bits_per_sample().iter().all(|x| *x == 8));
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use async_tiff::metadata::{PrefetchBuffer, TiffMetadataReader};
+use async_tiff::reader::{AsyncFileReader, ObjectReader};
+use async_tiff::TIFF;
+use reqwest::Url;
+
+pub(crate) async fn open_remote_tiff(url: &str) -> TIFF {
+    let parsed_url = Url::parse(url).expect("failed parsing url");
+    let (store, path) = object_store::parse_url(&parsed_url).unwrap();
+
+    let reader = Arc::new(ObjectReader::new(Arc::new(store), path)) as Arc<dyn AsyncFileReader>;
+    let prefetch_reader = PrefetchBuffer::new(reader.clone(), 32 * 1024)
+        .await
+        .unwrap();
+    let mut metadata_reader = TiffMetadataReader::try_open(&prefetch_reader)
+        .await
+        .unwrap();
+    let ifds = metadata_reader
+        .read_all_ifds(&prefetch_reader)
+        .await
+        .unwrap();
+    TIFF::new(ifds)
+}


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Ensure that a single-channel OME-TIFF files can be opened by `async-tiff`

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Created a helper `open_remote_tiff` utility function to read TIFFs from object stores
- Added a test to open an OME-TIFF file from https://downloads.openmicroscopy.org/images/OME-TIFF/2016-06/bioformats-artificial/single-channel.ome.tif, ensuring that the ImageDescription [OME XML metadata](https://ome-model.readthedocs.io/en/stable/ome-tiff/specification.html#ome-xml-metadata) is parsed out correctly.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- Run `cargo test` locally or look at CI logs

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #101
