### PR TITLE
added `DecodingResult`  struct, changed decoding and predictor API to allow in-place 

### DIFF
--- a/src/bytecast.rs
+++ b/src/bytecast.rs
@@ -1,0 +1,36 @@
+//! Trivial, internal byte transmutation.
+//!
+//! A dependency like bytemuck would give us extra assurance of the safety but overall would not
+//! reduce the amount of total unsafety. We don't use it in the interface where the traits would
+//! really become useful.
+//!
+//! SAFETY: These are benign casts as we apply them to fixed size integer types only. All of them
+//! are naturally aligned, valid for all bit patterns and their alignment is surely at most their
+//! size (we assert the latter fact since it is 'implementation defined' if following the letter of
+//! the unsafe code guidelines).
+//!
+//! TODO: Would like to use std-lib here.
+// from image-tiff src/bytecast.rs
+// see https://stackoverflow.com/a/29042896/14681457
+use std::{mem, slice};
+
+macro_rules! integral_slice_as_bytes{($int:ty, $const:ident $(,$mut:ident)*) => {
+    pub(crate) fn $const(slice: &[$int]) -> &[u8] {
+        assert!(mem::align_of::<$int>() <= mem::size_of::<$int>());
+        unsafe { slice::from_raw_parts(slice.as_ptr() as *const u8, mem::size_of_val(slice)) }
+    }
+    $(pub(crate) fn $mut(slice: &mut [$int]) -> &mut [u8] {
+        assert!(mem::align_of::<$int>() <= mem::size_of::<$int>());
+        unsafe { slice::from_raw_parts_mut(slice.as_mut_ptr() as *mut u8, mem::size_of_val(slice)) }
+    })*
+}}
+
+integral_slice_as_bytes!(i8, i8_as_ne_bytes, i8_as_ne_mut_bytes);
+integral_slice_as_bytes!(u16, u16_as_ne_bytes, u16_as_ne_mut_bytes);
+integral_slice_as_bytes!(i16, i16_as_ne_bytes, i16_as_ne_mut_bytes);
+integral_slice_as_bytes!(u32, u32_as_ne_bytes, u32_as_ne_mut_bytes);
+integral_slice_as_bytes!(i32, i32_as_ne_bytes, i32_as_ne_mut_bytes);
+integral_slice_as_bytes!(u64, u64_as_ne_bytes, u64_as_ne_mut_bytes);
+integral_slice_as_bytes!(i64, i64_as_ne_bytes, i64_as_ne_mut_bytes);
+integral_slice_as_bytes!(f32, f32_as_ne_bytes, f32_as_ne_mut_bytes);
+integral_slice_as_bytes!(f64, f64_as_ne_bytes, f64_as_ne_mut_bytes);

--- a/src/cog.rs
+++ b/src/cog.rs
@@ -52,7 +52,7 @@ mod test {
         let ifd = &tiff.ifds[1];
         let tile = ifd.fetch_tile(0, 0, reader.as_ref()).await.unwrap();
         let tile = tile.decode(&Default::default()).unwrap();
-        std::fs::write("img.buf", tile).unwrap();
+        std::fs::write("img.buf", tile.as_u8_buf()).unwrap();
     }
 
     #[ignore = "local file"]

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -7,7 +7,7 @@ use std::io::{Cursor, Read};
 use bytes::Bytes;
 use flate2::bufread::ZlibDecoder;
 
-use crate::error::{AsyncTiffResult, AsyncTiffError};
+use crate::error::{AsyncTiffError, AsyncTiffResult};
 use crate::tiff::tags::{CompressionMethod, PhotometricInterpretation};
 use crate::tiff::{TiffError, TiffUnsupportedError};
 
@@ -114,14 +114,15 @@ impl Decoder for LZWDecoder {
     ) -> AsyncTiffResult<()> {
         // https://github.com/image-rs/image-tiff/blob/90ae5b8e54356a35e266fb24e969aafbcb26e990/src/decoder/stream.rs#L147
         let mut decoder = weezl::decode::Decoder::with_tiff_size_switch(weezl::BitOrder::Msb, 8);
-        let buf_res = decoder
-            .decode_bytes(&compressed_buffer, result_buffer);
+        let buf_res = decoder.decode_bytes(&compressed_buffer, result_buffer);
         match buf_res.status {
             Err(e) => Err(AsyncTiffError::External(Box::new(e))),
             Ok(lzw_status) => match lzw_status {
                 weezl::LzwStatus::Ok | weezl::LzwStatus::Done => Ok(()),
-                weezl::LzwStatus::NoProgress => Err(AsyncTiffError::General("Internal LZW decoder reported no progress".into()))
-            }
+                weezl::LzwStatus::NoProgress => Err(AsyncTiffError::General(
+                    "Internal LZW decoder reported no progress".into(),
+                )),
+            },
         }
     }
 }

--- a/src/decoding_result.rs
+++ b/src/decoding_result.rs
@@ -1,0 +1,123 @@
+use crate::{
+    bytecast::*,
+    error::{AsyncTiffError, AsyncTiffResult},
+    predictor::PredictorInfo,
+    tiff::{tags::SampleFormat, TiffError, TiffUnsupportedError},
+};
+
+/// Result of a decoding process
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum DecodingResult {
+    /// A vector of unsigned bytes
+    U8(Vec<u8>),
+    /// A vector of unsigned words
+    U16(Vec<u16>),
+    /// A vector of 32 bit unsigned ints
+    U32(Vec<u32>),
+    /// A vector of 64 bit unsigned ints
+    U64(Vec<u64>),
+    /// A vector of 32 bit IEEE floats
+    F32(Vec<f32>),
+    /// A vector of 64 bit IEEE floats
+    F64(Vec<f64>),
+    /// A vector of 8 bit signed ints
+    I8(Vec<i8>),
+    /// A vector of 16 bit signed ints
+    I16(Vec<i16>),
+    /// A vector of 32 bit signed ints
+    I32(Vec<i32>),
+    /// A vector of 64 bit signed ints
+    I64(Vec<i64>),
+}
+
+impl DecodingResult {
+    /// use this result as a `&mut[u8]` buffer
+    pub fn as_mut_u8_buf(&mut self) -> &mut [u8] {
+        match self {
+            DecodingResult::U8(v) => v,
+            DecodingResult::U16(v) => u16_as_ne_mut_bytes(v),
+            DecodingResult::U32(v) => u32_as_ne_mut_bytes(v),
+            DecodingResult::U64(v) => u64_as_ne_mut_bytes(v),
+            DecodingResult::I8(v) => i8_as_ne_mut_bytes(v),
+            DecodingResult::I16(v) => i16_as_ne_mut_bytes(v),
+            DecodingResult::I32(v) => i32_as_ne_mut_bytes(v),
+            DecodingResult::I64(v) => i64_as_ne_mut_bytes(v),
+            DecodingResult::F32(v) => f32_as_ne_mut_bytes(v),
+            DecodingResult::F64(v) => f64_as_ne_mut_bytes(v),
+        }
+    }
+
+    /// use this result as a `&[u8]` buffer
+    pub fn as_u8_buf(&self) -> &[u8] {
+        match self {
+            DecodingResult::U8(v) => v,
+            DecodingResult::U16(v) => u16_as_ne_bytes(v),
+            DecodingResult::U32(v) => u32_as_ne_bytes(v),
+            DecodingResult::U64(v) => u64_as_ne_bytes(v),
+            DecodingResult::I8(v) => i8_as_ne_bytes(v),
+            DecodingResult::I16(v) => i16_as_ne_bytes(v),
+            DecodingResult::I32(v) => i32_as_ne_bytes(v),
+            DecodingResult::I64(v) => i64_as_ne_bytes(v),
+            DecodingResult::F32(v) => f32_as_ne_bytes(v),
+            DecodingResult::F64(v) => f64_as_ne_bytes(v),
+        }
+    }
+
+    /// create a properly sized `Self` from PredictorInfo struct for a single chunk (tile/strip)
+    // similar to image-tiff's Decoder::result_buffer
+    pub fn from_predictor_info(
+        info: PredictorInfo,
+        chunk_x: usize,
+        chunk_y: usize,
+    ) -> AsyncTiffResult<Self> {
+        // this part is outside of result_buffer
+
+        // since the calculations are in pixels rather than bytes (predictors
+        // use bytes), we do them here, rather than adding even more functions
+        // to PredictorInfo
+        let width = info.chunk_width_pixels(chunk_x as _)?;
+        let height = info.output_rows(chunk_y as _)?;
+
+        let buffer_size = match (width as usize)
+            .checked_mul(height)
+            .and_then(|x| x.checked_mul(info.samples_per_pixel as _))
+        {
+            Some(s) => s,
+            None => return Err(AsyncTiffError::InternalTIFFError(TiffError::IntSizeError)),
+        };
+
+        let max_sample_bits = info.bits_per_sample();
+
+        match info.sample_format {
+            SampleFormat::Uint => match max_sample_bits {
+                n if n <= 8 => Ok(DecodingResult::U8(vec![0u8; buffer_size])),
+                n if n <= 16 => Ok(DecodingResult::U16(vec![0u16; buffer_size])),
+                n if n <= 32 => Ok(DecodingResult::U32(vec![0u32; buffer_size])),
+                n if n <= 64 => Ok(DecodingResult::U64(vec![0u64; buffer_size])),
+                n => Err(AsyncTiffError::InternalTIFFError(
+                    TiffError::UnsupportedError(TiffUnsupportedError::UnsupportedBitsPerChannel(n)),
+                )),
+            },
+            SampleFormat::Int => match max_sample_bits {
+                n if n <= 8 => Ok(DecodingResult::I8(vec![0i8; buffer_size])),
+                n if n <= 16 => Ok(DecodingResult::I16(vec![0i16; buffer_size])),
+                n if n <= 32 => Ok(DecodingResult::I32(vec![0i32; buffer_size])),
+                n if n <= 64 => Ok(DecodingResult::I64(vec![0i64; buffer_size])),
+                n => Err(AsyncTiffError::InternalTIFFError(
+                    TiffError::UnsupportedError(TiffUnsupportedError::UnsupportedBitsPerChannel(n)),
+                )),
+            },
+            SampleFormat::IEEEFP => match max_sample_bits {
+                32 => Ok(DecodingResult::F32(vec![0f32; buffer_size])),
+                64 => Ok(DecodingResult::F64(vec![0f64; buffer_size])),
+                n => Err(AsyncTiffError::InternalTIFFError(
+                    TiffError::UnsupportedError(TiffUnsupportedError::UnsupportedBitsPerChannel(n)),
+                )),
+            },
+            format => Err(AsyncTiffError::InternalTIFFError(
+                TiffUnsupportedError::UnsupportedSampleFormat(vec![format]).into(),
+            )),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,10 @@
 
 pub mod reader;
 // TODO: maybe rename this mod
+pub(crate) mod bytecast;
 mod cog;
 pub mod decoder;
+mod decoding_result;
 pub mod error;
 pub mod geo;
 mod ifd;
@@ -14,5 +16,6 @@ pub mod tiff;
 mod tile;
 
 pub use cog::TIFF;
+pub use decoding_result::DecodingResult;
 pub use ifd::ImageFileDirectory;
 pub use tile::Tile;

--- a/src/tiff/error.rs
+++ b/src/tiff/error.rs
@@ -159,7 +159,7 @@ pub enum TiffUnsupportedError {
     UnsupportedSampleDepth(u8),
     UnsupportedSampleFormat(Vec<SampleFormat>),
     // UnsupportedColorType(ColorType),
-    UnsupportedBitsPerChannel(u8),
+    UnsupportedBitsPerChannel(u16),
     UnsupportedPlanarConfig(Option<PlanarConfiguration>),
     UnsupportedDataType,
     UnsupportedInterpretation(PhotometricInterpretation),


### PR DESCRIPTION
closes #87 also #86 is somewhat relevant.

makes the output of a decoding operation a typed array.

The goals:
- output data is properly aligned and typed
- less-copy: try to copy the resulting data as little as possible
the problem:
1. data comes in as Bytes from the underlying network layer -> 1 copy is needed for typing+alignment (without extensive spec-reading and changing the api even more if we ever wanted to directly cast the Bytes to aligned+typed arrays)
2. some decompressions allow for reading into a buffer (deflate, lzw), others (~lzw~, jpeg) not. uncompressed copies because of 1
3. some predictors allow in-place (none: endianness-fixing and horizontal), others (float) not

The typed array can be filled in different places:
1. during decoding (breaking change, this PR)
2. during unpredicting (less breaking, leaves DecoderRegistry API untouched)
3. after unpredicting (current, the user does that here)

this PR does it during the decoding step, which:
- 6allows decompression algorithms to directly decompress into the buffer, saving a copy
- allows users to create their own typed buffers and decode into those using `decode_into`.

It changes quite some public api, so open to discussion. more comments coming on the changes

sidenote: there is a redundant copy with no compression and floating point prediction, but which sensible person would ever have that configuration?