### PR TITLE
added Endianness access from IFD to python

### DIFF
--- a/python/src/enums.rs
+++ b/python/src/enums.rs
@@ -1,10 +1,39 @@
-use async_tiff::tiff::tags::{
-    CompressionMethod, PhotometricInterpretation, PlanarConfiguration, Predictor, ResolutionUnit,
-    SampleFormat,
+use async_tiff::{
+    reader::Endianness,
+    tiff::tags::{
+        CompressionMethod, PhotometricInterpretation, PlanarConfiguration, Predictor,
+        ResolutionUnit, SampleFormat,
+    },
 };
 use pyo3::prelude::*;
 use pyo3::types::{PyString, PyTuple};
 use pyo3::{intern, IntoPyObjectExt};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[pyclass(eq, eq_int, name = "Endianness")]
+#[repr(u16)]
+pub(crate) enum PyEndianness {
+    LittleEndian = 0x4949, // b"II"
+    BigEndian = 0x4D4D,    // b"MM"
+}
+
+impl From<Endianness> for PyEndianness {
+    fn from(value: Endianness) -> Self {
+        match value {
+            Endianness::LittleEndian => Self::LittleEndian,
+            Endianness::BigEndian => Self::BigEndian,
+        }
+    }
+}
+
+impl From<PyEndianness> for Endianness {
+    fn from(value: PyEndianness) -> Self {
+        match value {
+            PyEndianness::LittleEndian => Self::LittleEndian,
+            PyEndianness::BigEndian => Self::BigEndian,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) struct PyCompressionMethod(CompressionMethod);

--- a/python/src/ifd.rs
+++ b/python/src/ifd.rs
@@ -4,8 +4,8 @@ use async_tiff::ImageFileDirectory;
 use pyo3::prelude::*;
 
 use crate::enums::{
-    PyCompressionMethod, PyPhotometricInterpretation, PyPlanarConfiguration, PyPredictor,
-    PyResolutionUnit, PySampleFormat,
+    PyCompressionMethod, PyEndianness, PyPhotometricInterpretation, PyPlanarConfiguration,
+    PyPredictor, PyResolutionUnit, PySampleFormat,
 };
 use crate::geo::PyGeoKeyDirectory;
 use crate::value::PyValue;
@@ -15,6 +15,11 @@ pub(crate) struct PyImageFileDirectory(ImageFileDirectory);
 
 #[pymethods]
 impl PyImageFileDirectory {
+    #[getter]
+    pub fn endianness(&self) -> PyEndianness {
+        self.0.endianness().into()
+    }
+
     #[getter]
     pub fn new_subfile_type(&self) -> Option<u32> {
         self.0.new_subfile_type()

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -402,6 +402,12 @@ impl ImageFileDirectory {
         })
     }
 
+
+    /// The Endianness of the file
+    pub fn endianness(&self) -> Endianness {
+        self.endianness
+    }
+
     /// A general indication of the kind of data contained in this subfile.
     /// <https://web.archive.org/web/20240329145250/https://www.awaresystems.be/imaging/tiff/tifftags/newsubfiletype.html>
     pub fn new_subfile_type(&self) -> Option<u32> {


### PR DESCRIPTION
closes #91 No unit tests yet. There were none before me in the Python part. Would be happy to add some with some pointers.

I chose to duplicate the enum in Python, so users can access it as `Endianness.LittleEndian` in Python as well, using pyo3 macro derivation.

I added the repr(u16) and custom discriminant on `PyEndianness` for matching tiff structure. I could reflect that in src/reader.rs::`Endianness` or drop completely.

It seems that `FromPyObject` trait impl is needed if we want to pass it into a rust function from the python side. Since we don't currently do that, I didn't implement it. Could be nicely done to accept all of `Endianness`, `u16` or `String` I think? I think in that case we need to also register the class in `python/src/lib.rs::_async_tiff` so they can actually create it in python. - I think that's needed anyways... will commit

I'm a bit unsure of the location of `PyEndianness` Since its an enum I put it in python/src/`enums.rs`, even though all enums there are tags. On the rust side `Endianness` is in `reader.rs`, which makes sense implementation-wise I think? What would be a good place? Or should we wait for repo layout (#69).

