### PR TITLE
chore!: Bump minimum Python version to 3.10

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "async-tiff"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["obspec>=0.1.0-beta.3"]
 dynamic = ["version"]
 classifiers = [


### PR DESCRIPTION
Python 3.9 is end of life in a week: https://endoflife.date/python