### PR TITLE
ci: Build abi3 wheels where possible

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -54,15 +54,24 @@ jobs:
           version: "0.5.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        run: uv python install 3.10 3.13 pypy3.10
 
-      - name: Build wheels
+      - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.13 --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
           manylinux: ${{ matrix.platform.manylinux }}
+
+      - name: Build version-specific wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.10 -i pypy3.10 --features extension-module --manifest-path python/Cargo.toml
+          sccache: "true"
+          manylinux: ${{ matrix.platform.manylinux }}
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -94,15 +103,24 @@ jobs:
           version: "0.5.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        run: uv python install 3.10 3.13 pypy3.10
 
-      - name: Build wheels
+      - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.13 --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
           manylinux: musllinux_1_2
+
+      - name: Build version-specific wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.10 -i pypy3.10 --features extension-module --manifest-path python/Cargo.toml
+          sccache: "true"
+          manylinux: musllinux_1_2
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -131,12 +149,21 @@ jobs:
       - name: Remove symlink (not supported in Windows wheels)
         run: Remove-Item -Path python/python/async_tiff/store -Force
         shell: pwsh
-      - name: Build wheels
+
+      - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.13 --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
+
+      - name: Build version-specific wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.10 --features extension-module --manifest-path python/Cargo.toml
+          sccache: "true"
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -164,14 +191,22 @@ jobs:
           version: "0.5.x"
 
       - name: Install Python versions
-        run: uv python install 3.9 3.10 3.11 3.12 3.13 pypy3.10
+        run: uv python install 3.10 3.13 pypy3.10
 
-      - name: Build wheels
+      - name: Build abi3-py311 wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.9 -i 3.10 -i 3.11 -i 3.12 -i 3.13 -i pypy3.10 --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.13 --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
+
+      - name: Build version-specific wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i 3.10 -i pypy3.10 --features extension-module --manifest-path python/Cargo.toml
+          sccache: "true"
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -205,7 +240,7 @@ jobs:
     #   # IMPORTANT: this permission is mandatory for trusted publishing
     #   id-token: write
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [linux, musllinux, macos]
+    needs: [linux, musllinux, windows, macos]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,6 +16,10 @@ rust-version = "1.75"
 name = "_async_tiff"
 crate-type = ["cdylib"]
 
+[features]
+abi3-py311 = ["pyo3/abi3-py311"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
 async-tiff = { path = "../" }
 bytes = "1.10.1"


### PR DESCRIPTION
Port of https://github.com/kylebarron/arro3/pull/408.

We can't build _only_ abi3 wheels yet because we use the buffer protocol (in `pyo3-bytes`) and the buffer protocol is only on the limited API as of py3.11. 

But here we build only two sets of wheels: version-specific wheels in py3.10 and then abi3 wheels for everything after that. (We should add free-threading wheels in the future too)

Testing wheel build here: https://github.com/developmentseed/async-tiff/actions/runs/18753544097

cc @maxrjones, after this we can bump version and publish