### PR TITLE
ci: Fix tag name to initiate rust release

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,8 +1,8 @@
 name: Publish to crates.io
 on:
   push:
-    # Triggers when pushing tags starting with 'v'
-    tags: ["v*"]
+    # Triggers when pushing tags starting with 'rust-v'
+    tags: ["rust-v*"]
 
 jobs:
   publish:


### PR DESCRIPTION
The format of rust tags on this repo are of `rust-v*`