### PR TITLE
feat: Include Endianness as property of TIFF struct

### DIFF
--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -1,10 +1,12 @@
 from typing import Protocol
-from ._tile import Tile
-from ._ifd import ImageFileDirectory
-from .store import ObjectStore
 
 # Fix exports
 from obspec._get import GetRangeAsync, GetRangesAsync
+
+from ._ifd import ImageFileDirectory
+from ._tile import Tile
+from .enums import Endianness
+from .store import ObjectStore
 
 class ObspecInput(GetRangeAsync, GetRangesAsync, Protocol):
     """Supported obspec input to reader."""
@@ -33,6 +35,10 @@ class TIFF:
         Returns:
             A TIFF instance.
         """
+
+    @property
+    def endianness(self) -> Endianness:
+        """The endianness of this TIFF file."""
     @property
     def ifds(self) -> list[ImageFileDirectory]:
         """Access the underlying IFDs of this TIFF.

--- a/python/python/async_tiff/enums.py
+++ b/python/python/async_tiff/enums.py
@@ -21,6 +21,11 @@ class CompressionMethod(IntEnum):
     PackBits = 0x8005
 
 
+class Endianness(IntEnum):
+    LittleEndian = 0
+    BigEndian = 1
+
+
 class PhotometricInterpretation(IntEnum):
     WhiteIsZero = 0
     BlackIsZero = 1

--- a/python/src/enums.rs
+++ b/python/src/enums.rs
@@ -1,3 +1,4 @@
+use async_tiff::reader::Endianness;
 use async_tiff::tiff::tags::{
     CompressionMethod, PhotometricInterpretation, PlanarConfiguration, Predictor, ResolutionUnit,
     SampleFormat,
@@ -36,6 +37,30 @@ impl<'py> IntoPyObject<'py> for PyCompressionMethod {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         to_py_enum_variant(py, intern!(py, "CompressionMethod"), self.0.to_u16())
+    }
+}
+
+pub(crate) struct PyEndianness(Endianness);
+
+impl From<Endianness> for PyEndianness {
+    fn from(value: Endianness) -> Self {
+        Self(value)
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyEndianness {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let enums_mod = py.import(intern!(py, "async_tiff.enums"))?;
+        let endianness_enum = enums_mod.getattr(intern!(py, "Endianness"))?;
+
+        match self.0 {
+            Endianness::LittleEndian => endianness_enum.getattr("LittleEndian"),
+            Endianness::BigEndian => endianness_enum.getattr("BigEndian"),
+        }
     }
 }
 
@@ -132,6 +157,7 @@ impl<'py> IntoPyObject<'py> for PySampleFormat {
         to_py_enum_variant(py, intern!(py, "SampleFormat"), self.0.to_u16())
     }
 }
+
 fn to_py_enum_variant<'py>(
     py: Python<'py>,
     enum_name: &Bound<'py, PyString>,

--- a/python/tests/test_cog.py
+++ b/python/tests/test_cog.py
@@ -13,6 +13,8 @@ async def test_cog_s3():
     store = S3Store("sentinel-cogs", region="us-west-2", skip_signature=True)
     tiff = await TIFF.open(path=path, store=store)
 
+    assert tiff.endianness == enums.Endianness.LittleEndian
+
     ifds = tiff.ifds
     assert len(ifds) == 5
 

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -9,7 +9,7 @@ use crate::metadata::MetadataFetch;
 use crate::reader::Endianness;
 use crate::tiff::tags::{Tag, Type};
 use crate::tiff::{TiffError, TiffFormatError, Value};
-use crate::ImageFileDirectory;
+use crate::{ImageFileDirectory, TIFF};
 
 /// Entry point to reading TIFF metadata.
 ///
@@ -134,6 +134,12 @@ impl TiffMetadataReader {
             ifds.push(ifd);
         }
         Ok(ifds)
+    }
+
+    /// Read all IFDs from the file and return a complete TIFF structure.
+    pub async fn read<F: MetadataFetch>(&mut self, fetch: &F) -> AsyncTiffResult<TIFF> {
+        let ifds = self.read_all_ifds(fetch).await?;
+        Ok(TIFF::new(ifds, self.endianness))
     }
 }
 

--- a/tests/image_tiff/util.rs
+++ b/tests/image_tiff/util.rs
@@ -14,6 +14,5 @@ pub(crate) async fn open_tiff(filename: &str) -> TIFF {
     let reader = Arc::new(ObjectReader::new(store.clone(), path.as_str().into()))
         as Arc<dyn AsyncFileReader>;
     let mut metadata_reader = TiffMetadataReader::try_open(&reader).await.unwrap();
-    let ifds = metadata_reader.read_all_ifds(&reader).await.unwrap();
-    TIFF::new(ifds)
+    metadata_reader.read(&reader).await.unwrap()
 }

--- a/tests/ome_tiff.rs
+++ b/tests/ome_tiff.rs
@@ -16,8 +16,7 @@ async fn open_remote_tiff(url: &str) -> TIFF {
     let reader = Arc::new(ObjectReader::new(Arc::new(store), path)) as Arc<dyn AsyncFileReader>;
     let cached_reader = ReadaheadMetadataCache::new(reader.clone());
     let mut metadata_reader = TiffMetadataReader::try_open(&cached_reader).await.unwrap();
-    let ifds = metadata_reader.read_all_ifds(&cached_reader).await.unwrap();
-    TIFF::new(ifds)
+    metadata_reader.read(&cached_reader).await.unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
While the endianness is needed in the IFD parser, it's a _property_ of the file itself, as the Endianness is described in the first few bytes of the file.

This adds `Endianness` as a property of the `TIFF` struct and exposes it to Python.

Closes https://github.com/developmentseed/async-tiff/pull/106, closes https://github.com/developmentseed/async-tiff/issues/91