### PR TITLE
feat: Add ZSTD Decoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ reqwest = { version = "0.12", default-features = false, optional = true }
 thiserror = "1"
 tokio = { version = "1.43.0", default-features = false, features = ["sync"] }
 weezl = "0.1.0"
+zstd = "0.13"
 
 [dev-dependencies]
 object_store = { version = "0.12", features = ["http"] }

--- a/tests/image_tiff/decode_images.rs
+++ b/tests/image_tiff/decode_images.rs
@@ -225,6 +225,17 @@ async fn test_int16_rgb() {
 }
 
 #[tokio::test]
+async fn test_zstd_compression() {
+    let tiff = open_tiff("int16_zstd.tif").await;
+    let ifd = &tiff.ifds()[0];
+    assert!(matches!(
+        ifd.photometric_interpretation(),
+        PhotometricInterpretation::BlackIsZero
+    ));
+    assert!(ifd.bits_per_sample().iter().all(|x| *x == 16));
+}
+
+#[tokio::test]
 async fn test_string_tags() {
     // these files have null-terminated strings for their Software tag. One has extra bytes after
     // the null byte, so we check both to ensure that we're truncating properly


### PR DESCRIPTION
Hi!

Added a decoder for ZSTD (#153) and wrote a test similar to how you have tested before. Also verified that it runs E2E with some Python scripts (not part of PR) on my own test files, and it works great!

Thank you once again for a great lib!

Closes #153