### PR TITLE
feat: Allow Python-level subclassing of `TIFF` class

### DIFF
--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -15,7 +15,7 @@ use crate::reader::StoreInput;
 use crate::tile::PyTile;
 use crate::PyImageFileDirectory;
 
-#[pyclass(name = "TIFF", frozen)]
+#[pyclass(name = "TIFF", frozen, subclass)]
 pub(crate) struct PyTIFF {
     tiff: TIFF,
     reader: Arc<dyn AsyncFileReader>,


### PR DESCRIPTION
Means that downstream in `async-geotiff` we can create a `GeoTIFF` subclass