### PR TITLE
chore: Bump python package version to 0.4.0-beta.1

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "py-async-tiff"
-version = "0.3.0"
+version = "0.4.0-beta.1"
 dependencies = [
  "async-tiff",
  "async-trait",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-async-tiff"
-version = "0.3.0"
+version = "0.4.0-beta.1"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 # description = "Fast, memory-efficient 2D spatial indexes for Python."


### PR DESCRIPTION
Initial pre-publish for v0.4. We still need to resolve https://github.com/developmentseed/async-tiff/pull/139#discussion_r2719341474 before publishing 0.4