### PR TITLE
chore: Add additional license copyright from image-tiff

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2018 PistonDevelopers
 Copyright (c) 2024 Development Seed
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ println!("shape: {:?}, dtype: {:?}", array.shape(), array.data_type());
 ## Background
 
 The existing [`tiff` crate](https://crates.io/crates/tiff) is great, but only supports synchronous reading of TIFF files. Furthermore, due to low maintenance bandwidth it is not designed for extensibility (see [#250](https://github.com/image-rs/image-tiff/issues/250)).
+
+This crate was initially forked from the `tiff` crate, and still maintains some of its TIFF tag parsing code.


### PR DESCRIPTION
Add additional line of copyright on the MIT license page from https://github.com/image-rs/image-tiff/blob/99a7b8cba7330944abe1bf6797def12bbf13a9a0/LICENSE#L3

Closes #199 