### PR TITLE
feat(python): Add `IFD.fetch_tile` and `IFD.fetch_tiles`

### DIFF
--- a/python/python/async_tiff/_ifd.pyi
+++ b/python/python/async_tiff/_ifd.pyi
@@ -1,7 +1,8 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from ._geo import GeoKeyDirectory
+from ._tile import Tile
 from .enums import (
     CompressionMethod,
     PhotometricInterpretation,
@@ -122,3 +123,23 @@ class ImageFileDirectory:
     def gdal_metadata(self) -> str | None: ...
     @property
     def other_tags(self) -> dict[int, Value]: ...
+    async def fetch_tile(self, x: int, y: int) -> Tile:
+        """Fetch a single tile.
+
+        Args:
+            x: The column index within the ifd to read from.
+            y: The row index within the ifd to read from.
+
+        Returns:
+            Tile response.
+        """
+    async def fetch_tiles(self, x: Sequence[int], y: Sequence[int]) -> list[Tile]:
+        """Fetch multiple tiles concurrently.
+
+        Args:
+            x: The column indexes within the ifd to read from.
+            y: The row indexes within the ifd to read from.
+
+        Returns:
+            Tile responses.
+        """

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from ._ifd import ImageFileDirectory
 from ._input import ObspecInput
 from ._tile import Tile
@@ -32,6 +34,17 @@ class TIFF:
     @property
     def endianness(self) -> Endianness:
         """The endianness of this TIFF file."""
+
+    def ifd(self, index: int) -> ImageFileDirectory:
+        """Access a specific IFD by index.
+
+        Args:
+            index: The IFD index to access.
+
+        Returns:
+            The requested IFD.
+        """
+
     @property
     def ifds(self) -> list[ImageFileDirectory]:
         """Access the underlying IFDs of this TIFF.
@@ -50,7 +63,9 @@ class TIFF:
         Returns:
             Tile response.
         """
-    async def fetch_tiles(self, x: list[int], y: list[int], z: int) -> list[Tile]:
+    async def fetch_tiles(
+        self, x: Sequence[int], y: Sequence[int], z: int
+    ) -> list[Tile]:
         """Fetch multiple tiles concurrently.
 
         Args:


### PR DESCRIPTION
Previously, the `fetch_tile` method was only available on `TIFF`. This causes some awkward code in async-geotiff where we have to store a reference to the _index_ of an IFD because we can't make a fetch on the IFD directly.

With this PR it should be possible to have cleaner code in `async-geotiff` by only ever requiring a reference to the IFD. This should also make it cleaner to implement external masks and overviews (https://github.com/developmentseed/async-geotiff/issues/32, https://github.com/developmentseed/async-geotiff/issues/31), because we can just store the IFD object of the external mask/overview, and read from them as if they were in the same file.

Closes https://github.com/developmentseed/async-tiff/issues/198