### PR TITLE
fix(python): Fix linked inventories in mkdocs

### DIFF
--- a/python/mkdocs.yml
+++ b/python/mkdocs.yml
@@ -120,7 +120,7 @@ plugins:
             extensions:
               - griffe_inherited_docstrings
 
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
             - https://developmentseed.org/obstore/latest/objects.inv
 


### PR DESCRIPTION
The mkdocstrings yaml key for external inventories was renamed to `inventories`, not `import`.

Closes https://github.com/developmentseed/async-tiff/issues/209