### PR TITLE
ci(python)!: Remove unsupported linux platforms from wheel build

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -33,12 +33,6 @@ jobs:
           - runner: ubuntu-latest
             target: aarch64
             manylinux: "2_24"
-          - runner: ubuntu-latest
-            target: s390x
-            manylinux: auto
-          - runner: ubuntu-latest
-            target: ppc64le
-            manylinux: auto
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
These platforms are better considered as _potentials to add in the future_, rather than ones we should support up front.