### PR TITLE
fix(python): Fix obspec imports

### DIFF
--- a/python/python/async_tiff/_input.py
+++ b/python/python/async_tiff/_input.py
@@ -1,8 +1,11 @@
 from typing import Protocol
 
-# Fix exports
-from obspec._get import GetRangeAsync, GetRangesAsync
+from obspec import GetRangeAsync, GetRangesAsync
 
 
 class ObspecInput(GetRangeAsync, GetRangesAsync, Protocol):
-    """Supported obspec input to reader."""
+    """Supported obspec input to reader.
+
+    Anything that implements [GetRangeAsync][obspec.GetRangeAsync] and
+    [GetRangesAsync][obspec.GetRangesAsync] can be used as an input to the TIFF reader.
+    """


### PR DESCRIPTION
Since https://github.com/developmentseed/obspec/pull/11 we can import from the top-level module

Closes #227 

Validated that the docs display correctly too:
<img width="740" height="205" alt="image" src="https://github.com/user-attachments/assets/e57e9154-0b24-4978-869d-c612d4f3e240" />

