### PR TITLE
feat: Change `fetch_tiles` to take tuples of `(x, y)` instead of two separate vecs

### DIFF
--- a/benches/read_tiff.rs
+++ b/benches/read_tiff.rs
@@ -44,12 +44,11 @@ async fn read_tiles<R: AsyncFileReader + Clone>(reader: R) -> AsyncTiffResult<Ve
     ))?;
 
     // Get cartesian product of x and y tile ids
-    let x_ids: Vec<usize> = (0..x_count)
-        .flat_map(|i| (0..y_count).map(move |_j| i))
+    let xy_ids: Vec<(usize, usize)> = (0..x_count)
+        .flat_map(|i| (0..y_count).map(move |j| (i, j)))
         .collect();
-    let y_ids: Vec<usize> = (0..x_count).flat_map(|_i| 0..y_count).collect();
 
-    let tiles: Vec<Tile> = ifd.fetch_tiles(&x_ids, &y_ids, &reader).await?;
+    let tiles: Vec<Tile> = ifd.fetch_tiles(&xy_ids, &reader).await?;
     Ok(tiles)
 }
 

--- a/python/python/async_tiff/_ifd.pyi
+++ b/python/python/async_tiff/_ifd.pyi
@@ -138,12 +138,11 @@ class ImageFileDirectory:
         Returns:
             Tile response.
         """
-    async def fetch_tiles(self, x: Sequence[int], y: Sequence[int]) -> list[Tile]:
+    async def fetch_tiles(self, xy: Sequence[tuple[int, int]]) -> list[Tile]:
         """Fetch multiple tiles concurrently.
 
         Args:
-            x: The column indexes within the ifd to read from.
-            y: The row indexes within the ifd to read from.
+            xy: The (column, row) indexes within the ifd to read from.
 
         Returns:
             Tile responses.

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -63,14 +63,11 @@ class TIFF:
         Returns:
             Tile response.
         """
-    async def fetch_tiles(
-        self, x: Sequence[int], y: Sequence[int], z: int
-    ) -> list[Tile]:
+    async def fetch_tiles(self, xy: Sequence[tuple[int, int]], z: int) -> list[Tile]:
         """Fetch multiple tiles concurrently.
 
         Args:
-            x: The column indexes within the ifd to read from.
-            y: The row indexes within the ifd to read from.
+            xy: The (column, row) indexes within the ifd to read from.
             z: The IFD index to read from.
 
         Returns:

--- a/python/src/ifd.rs
+++ b/python/src/ifd.rs
@@ -458,14 +458,13 @@ impl PyImageFileDirectory {
     pub(crate) fn fetch_tiles<'py>(
         &'py self,
         py: Python<'py>,
-        x: Vec<usize>,
-        y: Vec<usize>,
+        xy: Vec<(usize, usize)>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let reader = self.reader.clone();
         let ifd = self.ifd.clone();
         future_into_py(py, async move {
             let tiles = ifd
-                .fetch_tiles(&x, &y, reader.as_ref())
+                .fetch_tiles(&xy, reader.as_ref())
                 .await
                 .map_err(|err| PyTypeError::new_err(err.to_string()))?;
             let py_tiles = tiles.into_iter().map(PyTile::new).collect::<Vec<_>>();

--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -109,8 +109,7 @@ impl PyTIFF {
     fn fetch_tiles<'py>(
         &'py self,
         py: Python<'py>,
-        x: Vec<usize>,
-        y: Vec<usize>,
+        xy: Vec<(usize, usize)>,
         z: usize,
     ) -> PyResult<Bound<'py, PyAny>> {
         let reader = self.reader.clone();
@@ -121,7 +120,7 @@ impl PyTIFF {
             .clone();
         future_into_py(py, async move {
             let tiles = ifd
-                .fetch_tiles(&x, &y, reader.as_ref())
+                .fetch_tiles(&xy, reader.as_ref())
                 .await
                 .map_err(|err| PyTypeError::new_err(err.to_string()))?;
             let py_tiles = tiles.into_iter().map(PyTile::new).collect::<Vec<_>>();


### PR DESCRIPTION
Closes https://github.com/developmentseed/async-tiff/issues/225