### PR TITLE
chore(python): Bump 0.6.0-beta.1

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "py-async-tiff"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 dependencies = [
  "async-tiff",
  "async-trait",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-async-tiff"
-version = "0.5.0"
+version = "0.6.0-beta.1"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 edition = "2021"
 description = "Fast, Async TIFF reader for Python with a Rust core."


### PR DESCRIPTION
To test LERC support in async-geotiff