### PR TITLE
ci(python): Fix python wheel build with LERC dependency

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -26,13 +26,13 @@ jobs:
         platform:
           - runner: ubuntu-latest
             target: x86_64
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-latest
             target: x86
-            manylinux: auto
+            manylinux: "2_28"
           - runner: ubuntu-latest
             target: aarch64
-            manylinux: "2_24"
+            manylinux: "2_28"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Change list

- Install clang on wheel build runners
- Bump manylinux to 2.28
	- https://github.com/pypa/manylinux
	- manylinux-timeline: https://mayeut.github.io/manylinux-timeline/
 	- Seems like the vast majority of modern linux distributions support manylinux 2.28: https://chatgpt.com/share/6984d8b3-34d0-8008-8844-905500cc35d2


Previously, the wheel build failed with the new LERC dependency:

```
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 0
  exit status: 0
  cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
  AR_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
  AR_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
  ARFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
  ARFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rustc-link-lib=static=lerc
  cargo:rustc-link-search=native=/home/runner/work/async-tiff/async-tiff/python/target/x86_64-unknown-linux-gnu/release/build/lerc-sys-08877c31fa2edcdb/out
  cargo:rerun-if-env-changed=CXXSTDLIB_x86_64-unknown-linux-gnu
  CXXSTDLIB_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CXXSTDLIB_x86_64_unknown_linux_gnu
  CXXSTDLIB_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CXXSTDLIB
  HOST_CXXSTDLIB = None
  cargo:rerun-if-env-changed=CXXSTDLIB
  CXXSTDLIB = None
  cargo:rustc-link-lib=stdc++
  cargo:rerun-if-changed=vendor/lerc/src/LercLib
  cargo:rerun-if-env-changed=TARGET
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64-unknown-linux-gnu
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS
  cargo:rerun-if-changed=vendor/lerc/src/LercLib/include/Lerc_c_api.h

  --- stderr

  thread 'main' (7238) panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bindgen-0.72.1/lib.rs:616:27:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_BUILD_EXTENSION_MODULE="1" PYO3_CONFIG_FILE="/home/runner/work/async-tiff/async-tiff/python/target/maturin/pyo3-config-x86_64-unknown-linux-gnu-3.13.txt" "cargo" "rustc" "--profile" "release" "--features" "abi3-py311" "--features" "extension-module" "--target" "x86_64-unknown-linux-gnu" "--message-format" "json-render-diagnostics" "--manifest-path" "/home/runner/work/async-tiff/async-tiff/python/Cargo.toml" "--lib"`
Error: The process '/usr/bin/docker' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:1823:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:1806:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:1700:27)
    at ChildProcess.emit (node:events:524:28)
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5)
```

https://github.com/developmentseed/async-tiff/actions/runs/21720669664/job/62649157709