### PR TITLE
ci: Remove lerc from musllinux wheel build

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -110,35 +110,17 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.13 --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.13 --no-default-features --features abi3-py311 --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
           manylinux: musllinux_1_2
-          before-script-linux: |
-            # Install libclang for bindgen (required by lerc-sys)
-            if command -v apk &> /dev/null; then
-              apk add clang-dev
-            elif command -v yum &> /dev/null; then
-              yum install -y clang-devel
-            elif command -v apt-get &> /dev/null; then
-              apt-get update && apt-get install -y libclang-dev
-            fi
 
       - name: Build version-specific wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i 3.10 -i pypy3.11 --features extension-module --manifest-path python/Cargo.toml
+          args: --release --out dist -i 3.10 -i pypy3.11 --no-default-features --features extension-module --manifest-path python/Cargo.toml
           sccache: "true"
           manylinux: musllinux_1_2
-          before-script-linux: |
-            # Install libclang for bindgen (required by lerc-sys)
-            if command -v apk &> /dev/null; then
-              apk add clang-dev
-            elif command -v yum &> /dev/null; then
-              yum install -y clang-devel
-            elif command -v apt-get &> /dev/null; then
-              apt-get update && apt-get install -y libclang-dev
-            fi
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -19,9 +19,11 @@ crate-type = ["cdylib"]
 [features]
 abi3-py311 = ["pyo3/abi3-py311"]
 extension-module = ["pyo3/extension-module"]
+lerc = ["async-tiff/lerc"]
+default = ["lerc"]
 
 [dependencies]
-async-tiff = { path = "../", features = ["jpeg2k", "webp", "lerc", "lzma"] }
+async-tiff = { path = "../", features = ["jpeg2k", "webp", "lzma"] }
 async-trait = "0.1.89"
 bytes = "1.10.1"
 futures = "0.3.31"


### PR DESCRIPTION
It looks like LERC compression support doesn't compile cleanly in musllinux. This PR removes LERC support for the musllinux wheels.