### PR TITLE
ci: apt install jq for bench workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,7 +17,7 @@ jobs:
   rust-bench:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/osgeo/gdal:ubuntu-small-3.11.5
+      image: ghcr.io/osgeo/gdal:ubuntu-small-3.12.2
       options: --privileged
     permissions:
       contents: read # required for actions/checkout


### PR DESCRIPTION
Try to fix `jq: command not found` when running CodSpeedHQ/action@v4.11.0

Seems like `jq` is needed after https://github.com/CodSpeedHQ/action/pull/189?

Fixes #254