### PR TITLE
docs: change plausible domain

### DIFF
--- a/python/mkdocs.yml
+++ b/python/mkdocs.yml
@@ -11,7 +11,7 @@ docs_dir: docs
 extra:
   analytics:
     provider: plausible
-    domain: async-tiff
+    domain: developmentseed.org/async-tiff
   social:
     - icon: "fontawesome/brands/github"
       link: "https://github.com/developmentseed"


### PR DESCRIPTION
Plausible used to work with any string for the domain. I think they've tied it to the domain now, so I updated the domain to match the domain of the docs site. 