### PR TITLE
feat: expose TIFF.header_byte_size for prefetch sizing

### DIFF
--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -35,6 +35,15 @@ class TIFF:
     def endianness(self) -> Endianness:
         """The endianness of this TIFF file."""
 
+    @property
+    def header_byte_size(self) -> int:
+        """Minimum prefetch size that covers all metadata.
+
+        Pass this value as ``prefetch=`` on a future :meth:`TIFF.open` call to
+        complete metadata reading in a single request. Computed as the minimum
+        non-zero offset across every IFD's ``TileOffsets`` and ``StripOffsets``.
+        """
+
     def ifd(self, index: int) -> ImageFileDirectory:
         """Access a specific IFD by index.
 

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -39,9 +39,9 @@ class TIFF:
     def header_byte_size(self) -> int:
         """Minimum prefetch size that covers all metadata.
 
-        Pass this value as ``prefetch=`` on a future :meth:`TIFF.open` call to
-        complete metadata reading in a single request. Computed as the minimum
-        non-zero offset across every IFD's ``TileOffsets`` and ``StripOffsets``.
+        Pass this value as `prefetch=` on a future `TIFF.open` call to complete
+        metadata reading in a single request. Computed as the minimum non-zero
+        offset across every IFD's `TileOffsets` and `StripOffsets`.
         """
 
     def ifd(self, index: int) -> ImageFileDirectory:

--- a/python/python/async_tiff/_tiff.pyi
+++ b/python/python/async_tiff/_tiff.pyi
@@ -39,9 +39,11 @@ class TIFF:
     def header_byte_size(self) -> int:
         """Minimum prefetch size that covers all metadata.
 
-        Pass this value as `prefetch=` on a future `TIFF.open` call to complete
-        metadata reading in a single request. Computed as the minimum non-zero
-        offset across every IFD's `TileOffsets` and `StripOffsets`.
+        Pass this value as `prefetch` on a future [`TIFF.open`][async_tiff.TIFF.open]
+        call to complete metadata reading in a single request.
+
+        This is computed as the minimum non-zero offset across every IFD's `TileOffsets`
+        and `StripOffsets`.
         """
 
     def ifd(self, index: int) -> ImageFileDirectory:

--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -66,6 +66,22 @@ impl PyTIFF {
         self.endianness.into()
     }
 
+    #[getter]
+    fn header_byte_size(&self) -> u64 {
+        self.ifds
+            .iter()
+            .flat_map(|ifd| {
+                ifd.tile_offsets()
+                    .into_iter()
+                    .chain(ifd.strip_offsets())
+                    .flatten()
+                    .copied()
+                    .filter(|&o| o != 0)
+            })
+            .min()
+            .expect("TIFF spec requires every IFD to have StripOffsets or TileOffsets")
+    }
+
     fn ifd(&self, index: usize) -> PyResult<PyImageFileDirectory> {
         let ifd = self
             .ifds

--- a/python/tests/test_tiff.py
+++ b/python/tests/test_tiff.py
@@ -29,3 +29,27 @@ async def test_read_band_interleaved_tiff_window(
         rasterio_data = rasterio_ds.read(window=window)
 
     np.testing.assert_array_equal(data, rasterio_data)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("variant", "file_name"), [("eox", "eox_cloudless")])
+async def test_header_byte_size(
+    load_tiff: LoadTIFF,
+    variant: str,
+    file_name: str,
+) -> None:
+    tiff = await load_tiff(file_name, variant=variant)
+
+    header = tiff.header_byte_size
+    assert isinstance(header, int)
+    assert header > 0
+
+    expected = min(
+        offset
+        for ifd in tiff.ifds
+        for offsets in (ifd.tile_offsets, ifd.strip_offsets)
+        if offsets is not None
+        for offset in offsets
+        if offset != 0
+    )
+    assert header == expected

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -2,4 +2,4 @@ mod geo;
 mod geotiff_test_data;
 mod image_tiff;
 mod ome_tiff;
-mod util;
+pub(crate) mod util;

--- a/src/tiff.rs
+++ b/src/tiff.rs
@@ -23,6 +23,32 @@ impl TIFF {
     pub fn endianness(&self) -> Endianness {
         self.endianness
     }
+
+    /// Returns the minimum prefetch size that covers all metadata.
+    ///
+    /// Computed as the minimum non-zero offset across every IFD's `TileOffsets`
+    /// and `StripOffsets`. For a typical Cloud-Optimized GeoTIFF, prefetching
+    /// this many bytes lets a future [`TIFF`] open complete metadata reading in
+    /// a single request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no IFD has either `TileOffsets` or `StripOffsets`. Per the TIFF
+    /// specification, every image IFD must have one of the two.
+    pub fn header_byte_size(&self) -> u64 {
+        self.ifds
+            .iter()
+            .flat_map(|ifd| {
+                ifd.tile_offsets()
+                    .into_iter()
+                    .chain(ifd.strip_offsets())
+                    .flatten()
+                    .copied()
+                    .filter(|&o| o != 0)
+            })
+            .min()
+            .expect("TIFF spec requires every IFD to have StripOffsets or TileOffsets")
+    }
 }
 
 #[cfg(test)]
@@ -38,6 +64,32 @@ mod test {
     use crate::metadata::TiffMetadataReader;
     use crate::reader::{AsyncFileReader, ObjectReader};
     use crate::TypedArray;
+
+    #[tokio::test]
+    async fn test_header_byte_size_matches_min_tile_offset() {
+        use crate::test::util::open_tiff;
+        let (_reader, tiff) = open_tiff(
+            "geotiff-test-data/rasterio_generated/fixtures/uint16_1band_lzw_block128_predictor2.tif",
+        )
+        .await;
+
+        let expected = tiff
+            .ifds()
+            .iter()
+            .flat_map(|ifd| {
+                ifd.tile_offsets()
+                    .into_iter()
+                    .chain(ifd.strip_offsets())
+                    .flatten()
+                    .copied()
+                    .filter(|&o| o != 0)
+            })
+            .min()
+            .expect("fixture must have at least one tile offset");
+
+        assert_eq!(tiff.header_byte_size(), expected);
+        assert!(tiff.header_byte_size() > 0);
+    }
 
     #[ignore = "local file"]
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `TIFF::header_byte_size()` (Rust) and `TIFF.header_byte_size` (Python) returning the minimum non-zero offset across every IFD's `TileOffsets` and `StripOffsets`.
- For a typical COG, this is the smallest `prefetch=` value that lets a future open complete metadata reading in a single request.
- Pure function over already-parsed IFDs — no changes to the metadata reader, fetch, or IFD types.

Closes #301.

## Test plan

- [x] New Rust test asserts the accessor matches the min-offset computation on an existing fixture.
- [x] New Python test mirrors the assertion through `TIFF.open` on the eox fixture.
- [x] \`cargo test --all-features\` — all 56 + 6 doctests pass.
- [x] \`pytest\` (python) — all 43 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)