### PR TITLE
feat: Relax 'Send' on `[async-trait]`

### DIFF
--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -1,0 +1,30 @@
+name: Wasm
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm_build:
+    name: Wasm build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: "recursive"
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo install wasm-pack
+
+      - name: Wasm target compilation
+        run: wasm-pack build

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -24,7 +24,5 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo install wasm-pack
-
       - name: Wasm target compilation
-        run: wasm-pack build
+        run: cargo check --target wasm32-unknown-unknown --lib

--- a/.github/workflows/wasm-build.yml
+++ b/.github/workflows/wasm-build.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,10 +19,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          submodules: "recursive"
+          persist-credentials: false
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@v2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ reqwest = ["dep:reqwest"]
 tokio = ["tokio/io-util"]
 webp = ["dep:webp"]
 
+
 [package.metadata.cargo-all-features]
 # The maximum number of features to try at once. Does not count features from
 # `always_include_features`. This is useful for reducing the number of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ tokio = ["tokio/io-util"]
 webp = ["dep:webp"]
 
 
+# Required for checking wasm compilation
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+
 [package.metadata.cargo-all-features]
 # The maximum number of features to try at once. Does not count features from
 # `always_include_features`. This is useful for reducing the number of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,6 @@ reqwest = ["dep:reqwest"]
 tokio = ["tokio/io-util"]
 webp = ["dep:webp"]
 
-
-# Required for checking wasm compilation
-[lib]
-crate-type = ["cdylib", "rlib"]
-
-
 [package.metadata.cargo-all-features]
 # The maximum number of features to try at once. Does not count features from
 # `always_include_features`. This is useful for reducing the number of

--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -143,7 +143,8 @@ impl<F: MetadataFetch> ReadaheadMetadataCache<F> {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<F: MetadataFetch + Send + Sync> MetadataFetch for ReadaheadMetadataCache<F> {
     async fn fetch(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         let mut cache = self.cache.lock().await;
@@ -190,7 +191,8 @@ mod test {
         }
     }
 
-    #[async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl MetadataFetch for TestFetch {
         async fn fetch(&self, range: Range<u64>) -> crate::error::AsyncTiffResult<Bytes> {
             if range.start as usize >= self.data.len() {

--- a/src/metadata/fetch.rs
+++ b/src/metadata/fetch.rs
@@ -12,7 +12,8 @@ use crate::reader::{AsyncFileReader, EndianAwareReader, Endianness};
 /// [`ImageFileDirectory`][crate::ImageFileDirectory]s.
 ///
 /// Note that implementation is provided for [`AsyncFileReader`].
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait MetadataFetch: Debug + Send + Sync + 'static {
     /// Return a future that fetches the specified range of bytes asynchronously
     ///
@@ -21,7 +22,8 @@ pub trait MetadataFetch: Debug + Send + Sync + 'static {
     async fn fetch(&self, range: Range<u64>) -> AsyncTiffResult<Bytes>;
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<T: AsyncFileReader> MetadataFetch for T {
     async fn fetch(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         self.get_bytes(range).await

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -631,7 +631,8 @@ mod test {
 
     use super::*;
 
-    #[async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl MetadataFetch for Bytes {
         async fn fetch(&self, range: std::ops::Range<u64>) -> crate::error::AsyncTiffResult<Bytes> {
             let usize_range = range.start as usize..range.end as usize;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -29,7 +29,8 @@ use crate::error::AsyncTiffResult;
 /// [`ObjectStore`]: object_store::ObjectStore
 ///
 /// [`tokio::fs::File`]: https://docs.rs/tokio/latest/tokio/fs/struct.File.html
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AsyncFileReader: Debug + Send + Sync + 'static {
     /// Retrieve the bytes in `range` as part of a request for image data, not header metadata.
     ///
@@ -52,7 +53,8 @@ pub trait AsyncFileReader: Debug + Send + Sync + 'static {
 }
 
 /// This allows Box<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
     async fn get_bytes(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         self.as_ref().get_bytes(range).await
@@ -64,7 +66,8 @@ impl AsyncFileReader for Box<dyn AsyncFileReader + '_> {
 }
 
 /// This allows Arc<dyn AsyncFileReader + '_> to be used as an AsyncFileReader,
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AsyncFileReader for Arc<dyn AsyncFileReader + '_> {
     async fn get_bytes(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         self.as_ref().get_bytes(range).await
@@ -121,7 +124,8 @@ impl<T: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin + Send + Debug> Toki
 }
 
 #[cfg(feature = "tokio")]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<T: tokio::io::AsyncRead + tokio::io::AsyncSeek + Unpin + Send + Debug + 'static>
     AsyncFileReader for TokioReader<T>
 {
@@ -158,7 +162,8 @@ impl ObjectReader {
 }
 
 #[cfg(feature = "object_store")]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AsyncFileReader for ObjectReader {
     async fn get_bytes(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         self.make_range_request(range).await
@@ -211,7 +216,8 @@ impl ReqwestReader {
 }
 
 #[cfg(feature = "reqwest")]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AsyncFileReader for ReqwestReader {
     async fn get_bytes(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         self.make_range_request(range).await


### PR DESCRIPTION
##  Allow compiling for  `wasm32-unknown-unknown` target with relaxed `Send` on `Future`

## Description

Atm, async-tiff fail to compile for `wasm32-unknown-unknown` target  because of the `Send` requirements on `Futures` implied by the `[async_trait]` decoration which is not set for  `wasm_bindgen_futures::JsFuture`.

That is, when using   a reader that return `wasm_bindgen_futures::JsFuture` (like `reqwest` does when compiling for `wasm32-unknown-unknown` the compilation fail with the following error:


```
error[E0277]: `Rc<RefCell<js_sys::futures::Inner>>` cannot be sent between threads safely
      --> /home/david/.cargo/git/checkouts/async-tiff-c522a11303546031/ce7753d/src/reader.rs:216:5
        |
216 |     async fn get_bytes(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
        |     ^^^^^
        |
        |     `Rc<RefCell<js_sys::futures::Inner>>` cannot be sent between threads safely
        |     within this `{async block@/home/david/.cargo/git/checkouts/async-tiff-c522a11303546031/ce7753d/src/reader.rs:216:5: 216:10}`
        |
        = help: within `{async block@/home/david/.cargo/git/checkouts/async-tiff-c522a11303546031/ce7753d/src/reader.rs:216:5: 216:10}`, the trait `std::marker::Send` is not implemented for `Rc<RefCell<js_sys::futures::Inner>>`
note: required because it appears within the type `js_sys::futures::JsFuture`
      --> /home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/js-sys-0.3.102/src/futures/mod.rs:118:12
        |
118 | pub struct  JsFuture<T = JsValue> {
        |                     ^^^^^^^^
note: required because it's used within this `async` fn body  
      --> /home/david/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/reqwest-0.13.4/src/wasm/mod.rs:34:1

...
```

## Solution
This can be fixed by relaxing the `Send`  constraint set by `[async_trait]` by using the `[async_trait(?Send)]`  annotation.

However I don't know if this appropriate in all cases when `Send` may be required on `Futures`. 
In this case, I wonder how te use a target configuration option without duplicating code (i.e that applies only on the `[async-trait]` decoration.


Thx for the job done with this crate !


