### PR TITLE
feat: Expose more IFD tags machinery to Python

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,8 +38,6 @@ dev-dependencies = [
     "pytest>=9.0",
     "rasterio>=1.4",
     "ruff>=0.15",
-    # writes the SubIFD fixture in test_ifd_tag_values.py; nothing else here can make one
-    "tifffile>=2024.1.30",
 ]
 
 [tool.pytest.ini_options]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,8 @@ dev-dependencies = [
     "pytest>=9.0",
     "rasterio>=1.4",
     "ruff>=0.15",
+    # writes the SubIFD fixture in test_ifd_tag_values.py; nothing else here can make one
+    "tifffile>=2024.1.30",
 ]
 
 [tool.pytest.ini_options]

--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -39,6 +39,22 @@ async fn open(
     })
 }
 
+async fn read_ifd_at(
+    reader: Arc<dyn AsyncFileReader>,
+    offset: u64,
+    prefetch: u64,
+    multiplier: f64,
+) -> PyAsyncTiffResult<PyImageFileDirectory> {
+    let metadata_fetch = ReadaheadMetadataCache::new(reader.clone())
+        .with_initial_size(prefetch)
+        .with_multiplier(multiplier);
+    // Re-reads the 16-byte header to learn the byte order and whether this is a BigTIFF, which
+    // decide how the directory at `offset` is laid out.
+    let metadata_reader = TiffMetadataReader::try_open(&metadata_fetch).await?;
+    let ifd = metadata_reader.read_ifd_at(&metadata_fetch, offset).await?;
+    Ok(PyImageFileDirectory::new(Arc::new(ifd), reader))
+}
+
 #[pymethods]
 impl PyTIFF {
     #[classmethod]
@@ -89,6 +105,24 @@ impl PyTIFF {
             .ok_or_else(|| PyIndexError::new_err(format!("No IFD found for index={index}")))?
             .clone();
         Ok(PyImageFileDirectory::new(ifd, self.reader.clone()))
+    }
+
+    /// Read an IFD at a byte offset, for directories outside the top-level chain.
+    ///
+    /// `ifds` follows the chain, which does not include SubIFDs (tag 330); those offsets are values
+    /// of that tag, and pyramid levels are commonly written there.
+    #[pyo3(signature = (offset, *, prefetch=32768, multiplier=2.0))]
+    fn ifd_at<'py>(
+        &'py self,
+        py: Python<'py>,
+        offset: u64,
+        prefetch: u64,
+        multiplier: f64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let reader = self.reader.clone();
+        future_into_py(py, async move {
+            Ok(read_ifd_at(reader, offset, prefetch, multiplier).await?)
+        })
     }
 
     #[getter]

--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -45,8 +45,8 @@ async fn read_ifd_at(
     prefetch: u64,
 ) -> PyAsyncTiffResult<PyImageFileDirectory> {
     let metadata_fetch = ReadaheadMetadataCache::new(reader.clone()).with_initial_size(prefetch);
-    // Re-reads the 16-byte header to learn the byte order and whether this is a BigTIFF, which
-    // decide how the directory at `offset` is laid out.
+    // Re-reads the 16-byte header to learn the byte order and whether the file is a BigTIFF.
+    // Those two facts decide the structure of the directory at `offset`.
     let metadata_reader = TiffMetadataReader::try_open(&metadata_fetch).await?;
     let ifd = metadata_reader.read_ifd_at(&metadata_fetch, offset).await?;
     Ok(PyImageFileDirectory::new(Arc::new(ifd), reader))

--- a/python/src/tiff.rs
+++ b/python/src/tiff.rs
@@ -43,11 +43,8 @@ async fn read_ifd_at(
     reader: Arc<dyn AsyncFileReader>,
     offset: u64,
     prefetch: u64,
-    multiplier: f64,
 ) -> PyAsyncTiffResult<PyImageFileDirectory> {
-    let metadata_fetch = ReadaheadMetadataCache::new(reader.clone())
-        .with_initial_size(prefetch)
-        .with_multiplier(multiplier);
+    let metadata_fetch = ReadaheadMetadataCache::new(reader.clone()).with_initial_size(prefetch);
     // Re-reads the 16-byte header to learn the byte order and whether this is a BigTIFF, which
     // decide how the directory at `offset` is laid out.
     let metadata_reader = TiffMetadataReader::try_open(&metadata_fetch).await?;
@@ -111,17 +108,16 @@ impl PyTIFF {
     ///
     /// `ifds` follows the chain, which does not include SubIFDs (tag 330); those offsets are values
     /// of that tag, and pyramid levels are commonly written there.
-    #[pyo3(signature = (offset, *, prefetch=32768, multiplier=2.0))]
+    #[pyo3(signature = (offset, *, prefetch=32768))]
     fn ifd_at<'py>(
         &'py self,
         py: Python<'py>,
         offset: u64,
         prefetch: u64,
-        multiplier: f64,
     ) -> PyResult<Bound<'py, PyAny>> {
         let reader = self.reader.clone();
         future_into_py(py, async move {
-            Ok(read_ifd_at(reader, offset, prefetch, multiplier).await?)
+            Ok(read_ifd_at(reader, offset, prefetch).await?)
         })
     }
 

--- a/python/src/value.rs
+++ b/python/src/value.rs
@@ -32,10 +32,12 @@ impl<'py> IntoPyObject<'py> for PyValue {
             TagValue::SRational(num, denom) => (num, denom).into_bound_py_any(py),
             TagValue::SRationalBig(num, denom) => (num, denom).into_bound_py_any(py),
             TagValue::Ascii(val) => val.into_bound_py_any(py),
-            TagValue::Ifd(_val) => Err(PyRuntimeError::new_err("Unsupported value type 'Ifd'")),
-            TagValue::IfdBig(_val) => {
-                Err(PyRuntimeError::new_err("Unsupported value type 'IfdBig'"))
-            }
+            // An IFD tag value is an offset into the file, so it converts like any other unsigned
+            // integer. Refusing it made whole files unreadable rather than one tag: tag 330
+            // (SubIFDs) is typed IFD in a classic TIFF and IFD8 in a BigTIFF, and the error surfaced
+            // while reading the directory, before any caller could choose to ignore the tag.
+            TagValue::Ifd(val) => val.into_bound_py_any(py),
+            TagValue::IfdBig(val) => val.into_bound_py_any(py),
             v => Err(PyRuntimeError::new_err(format!(
                 "Unknown value type: {v:?}"
             ))),

--- a/python/src/value.rs
+++ b/python/src/value.rs
@@ -33,9 +33,7 @@ impl<'py> IntoPyObject<'py> for PyValue {
             TagValue::SRationalBig(num, denom) => (num, denom).into_bound_py_any(py),
             TagValue::Ascii(val) => val.into_bound_py_any(py),
             // An IFD tag value is an offset into the file, so it converts like any other unsigned
-            // integer. Refusing it made whole files unreadable rather than one tag: tag 330
-            // (SubIFDs) is typed IFD in a classic TIFF and IFD8 in a BigTIFF, and the error surfaced
-            // while reading the directory, before any caller could choose to ignore the tag.
+            // integer. Tag 330 (SubIFDs) is typed IFD in a classic TIFF and IFD8 in a BigTIFF.
             TagValue::Ifd(val) => val.into_bound_py_any(py),
             TagValue::IfdBig(val) => val.into_bound_py_any(py),
             v => Err(PyRuntimeError::new_err(format!(

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -58,6 +58,8 @@ def load_tiff(fixture_store):
 
         if variant == "rasterio":
             path += "rasterio_generated/fixtures/"
+        elif variant == "tifffile":
+            path += "tifffile_generated/fixtures/"
         else:
             path += f"real_data/{variant}/"
 
@@ -80,6 +82,8 @@ def load_rasterio(fixtures_dir):
         path = f"{fixtures_dir}/geotiff-test-data/"
         if variant == "rasterio":
             path += "rasterio_generated/fixtures/"
+        elif variant == "tifffile":
+            path += "tifffile_generated/fixtures/"
         else:
             path += f"real_data/{variant}/"
 

--- a/python/tests/test_ifd_tag_values.py
+++ b/python/tests/test_ifd_tag_values.py
@@ -1,0 +1,68 @@
+"""Tags whose values are IFD offsets, which the Python layer used to refuse.
+
+`TagValue::Ifd` and `TagValue::IfdBig` were the only variants `PyValue` had no conversion for, so any
+file carrying such a tag raised `RuntimeError: Unsupported value type 'Ifd'` — and it raised while the
+directory was being read, before a caller could choose to ignore the tag. One tag made the whole file
+unopenable.
+
+The tag that matters in practice is 330, SubIFDs, which microscopy writers use for pyramid levels:
+typed IFD in a classic TIFF and IFD8 in a BigTIFF. The Rust core already parsed both and converts
+them to integers; only the binding declined.
+"""
+
+import numpy as np
+import pytest
+from async_tiff import TIFF
+from async_tiff.store import LocalStore
+
+tifffile = pytest.importorskip("tifffile")
+
+SUBIFDS_TAG = 330
+
+
+def write_with_subifd(path, *, bigtiff: bool) -> None:
+    """A two-level TIFF whose reduced level is a SubIFD rather than a second top-level IFD."""
+    full = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
+    with tifffile.TiffWriter(path, bigtiff=bigtiff) as writer:
+        writer.write(full, subifds=1, tile=(16, 16))
+        writer.write(full[::2, ::2], subfiletype=1, tile=(16, 16))
+
+
+@pytest.mark.parametrize(
+    ("bigtiff", "expected_type"),
+    [(False, "IFD"), (True, "IFD8")],
+    ids=["classic", "bigtiff"],
+)
+async def test_subifds_tag_reads_as_offsets(tmp_path, bigtiff, expected_type):
+    """The tag arrives as integers, and the file opens.
+
+    `expected_type` is the TIFF value type the writer uses, which is what distinguishes the two
+    variants this covers; both used to raise.
+    """
+    path = tmp_path / f"subifd_{expected_type.lower()}.tif"
+    write_with_subifd(path, bigtiff=bigtiff)
+    with tifffile.TiffFile(path) as reference:
+        assert reference.pages[0].tags[SUBIFDS_TAG].dtype_name == expected_type
+        assert reference.is_bigtiff is bigtiff
+
+    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
+    offsets = tiff.ifds[0].other_tags[SUBIFDS_TAG]
+
+    if isinstance(offsets, int):
+        offsets = [offsets]
+    assert offsets, "the tag carried no offsets"
+    assert all(isinstance(offset, int) for offset in offsets)
+    # An offset points inside the file, past the header.
+    assert all(0 < offset < path.stat().st_size for offset in offsets)
+
+
+async def test_the_image_beside_the_tag_still_reads(tmp_path):
+    """And the IFD carrying the tag is otherwise unaffected: its own tiles are where it says."""
+    path = tmp_path / "subifd_pixels.tif"
+    write_with_subifd(path, bigtiff=False)
+
+    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
+    ifd = tiff.ifds[0]
+    assert (ifd.image_height, ifd.image_width) == (64, 64)
+    assert ifd.tile_count == (4, 4)
+    assert len(ifd.tile_offsets) == 16

--- a/python/tests/test_ifd_tag_values.py
+++ b/python/tests/test_ifd_tag_values.py
@@ -1,81 +1,63 @@
 """Tags whose values are IFD offsets.
 
 The tag that matters in practice is 330, SubIFDs, which microscopy writers use for pyramid levels:
-typed IFD in a classic TIFF and IFD8 in a BigTIFF.
+typed IFD in a classic TIFF and IFD8 in a BigTIFF. The fixtures come from geotiff-test-data's
+tifffile_generated directory, one per type; each fixture's _info.md documents its layout.
 """
 
-import numpy as np
 import pytest
-from async_tiff import TIFF
-from async_tiff.store import LocalStore
-
-tifffile = pytest.importorskip("tifffile")
 
 SUBIFDS_TAG = 330
 
-
-def write_with_subifd(path, *, bigtiff: bool) -> None:
-    """A two-level TIFF whose reduced level is a SubIFD rather than a second top-level IFD."""
-    full = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
-    with tifffile.TiffWriter(path, bigtiff=bigtiff) as writer:
-        writer.write(full, subifds=1, tile=(16, 16))
-        writer.write(full[::2, ::2], subfiletype=1, tile=(16, 16))
-
-
-@pytest.mark.parametrize(
-    ("bigtiff", "expected_type"),
-    [(False, "IFD"), (True, "IFD8")],
+FIXTURES = pytest.mark.parametrize(
+    "name",
+    ["subifd_pyramid_classic", "subifd_pyramid_bigtiff"],
     ids=["classic", "bigtiff"],
 )
-async def test_subifds_tag_reads_as_offsets(tmp_path, bigtiff, expected_type):
-    """The tag arrives as integers, and the file opens.
 
-    `expected_type` is the TIFF value type the writer uses, which is what distinguishes the two
-    variants this covers; both used to raise.
-    """
-    path = tmp_path / f"subifd_{expected_type.lower()}.tif"
-    write_with_subifd(path, bigtiff=bigtiff)
-    with tifffile.TiffFile(path) as reference:
-        assert reference.pages[0].tags[SUBIFDS_TAG].dtype_name == expected_type
-        assert reference.is_bigtiff is bigtiff
 
-    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
+def subifd_offsets(tiff):
     offsets = tiff.ifds[0].other_tags[SUBIFDS_TAG]
+    return [offsets] if isinstance(offsets, int) else list(offsets)
 
-    if isinstance(offsets, int):
-        offsets = [offsets]
+
+@FIXTURES
+async def test_subifds_tag_reads_as_offsets(load_tiff, fixtures_dir, name):
+    """The tag arrives as integers, and the file opens; both variants used to raise."""
+    tiff = await load_tiff(name, variant="tifffile")
+    offsets = subifd_offsets(tiff)
+
     assert offsets, "the tag carried no offsets"
     assert all(isinstance(offset, int) for offset in offsets)
     # An offset points inside the file, past the header.
-    assert all(0 < offset < path.stat().st_size for offset in offsets)
+    size = (
+        (fixtures_dir / f"geotiff-test-data/tifffile_generated/fixtures/{name}.tif")
+        .stat()
+        .st_size
+    )
+    assert all(0 < offset < size for offset in offsets)
 
 
-async def test_subifds_can_be_read_at_their_offsets(tmp_path):
+@FIXTURES
+async def test_subifds_can_be_read_at_their_offsets(load_tiff, name):
     """And the levels they point at are reachable, which is the reason to expose the tag.
 
     `ifds` follows the top-level chain, which SubIFDs are not part of, so a pyramid written that way
     is invisible to a reader that only walks the chain -- one resolution out of however many.
     """
-    path = tmp_path / "subifd_levels.tif"
-    write_with_subifd(path, bigtiff=False)
+    tiff = await load_tiff(name, variant="tifffile")
+    assert len(tiff.ifds) == 1, "the reduced levels are not in the top-level chain"
 
-    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
-    assert len(tiff.ifds) == 1, "the reduced level is not in the top-level chain"
-
-    offsets = tiff.ifds[0].other_tags[SUBIFDS_TAG]
-    if isinstance(offsets, int):
-        offsets = [offsets]
-    reduced = await tiff.ifd_at(offsets[0])
-    assert (reduced.image_height, reduced.image_width) == (32, 32)
+    for offset, size in zip(subifd_offsets(tiff), (128, 64), strict=True):
+        level = await tiff.ifd_at(offset)
+        assert (level.image_height, level.image_width) == (size, size)
 
 
-async def test_the_image_beside_the_tag_still_reads(tmp_path):
+@FIXTURES
+async def test_the_image_beside_the_tag_still_reads(load_tiff, name):
     """And the IFD carrying the tag is otherwise unaffected: its own tiles are where it says."""
-    path = tmp_path / "subifd_pixels.tif"
-    write_with_subifd(path, bigtiff=False)
-
-    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
+    tiff = await load_tiff(name, variant="tifffile")
     ifd = tiff.ifds[0]
-    assert (ifd.image_height, ifd.image_width) == (64, 64)
+    assert (ifd.image_height, ifd.image_width) == (256, 256)
     assert ifd.tile_count == (4, 4)
     assert len(ifd.tile_offsets) == 16

--- a/python/tests/test_ifd_tag_values.py
+++ b/python/tests/test_ifd_tag_values.py
@@ -23,7 +23,7 @@ def subifd_offsets(tiff):
 
 @FIXTURES
 async def test_subifds_tag_reads_as_offsets(load_tiff, fixtures_dir, name):
-    """The tag arrives as integers, and the file opens; both variants used to raise."""
+    """The tag arrives as integers, and the file opens, for both variants."""
     tiff = await load_tiff(name, variant="tifffile")
     offsets = subifd_offsets(tiff)
 
@@ -42,8 +42,8 @@ async def test_subifds_tag_reads_as_offsets(load_tiff, fixtures_dir, name):
 async def test_subifds_can_be_read_at_their_offsets(load_tiff, name):
     """And the levels they point at are reachable, which is the reason to expose the tag.
 
-    `ifds` follows the top-level chain, which SubIFDs are not part of, so a pyramid written that way
-    is invisible to a reader that only walks the chain -- one resolution out of however many.
+    `ifds` follows the top-level chain, which SubIFDs are not part of, so a walk of the chain
+    alone finds one resolution level out of the total in the file.
     """
     tiff = await load_tiff(name, variant="tifffile")
     assert len(tiff.ifds) == 1, "the reduced levels are not in the top-level chain"
@@ -55,7 +55,7 @@ async def test_subifds_can_be_read_at_their_offsets(load_tiff, name):
 
 @FIXTURES
 async def test_the_image_beside_the_tag_still_reads(load_tiff, name):
-    """And the IFD carrying the tag is otherwise unaffected: its own tiles are where it says."""
+    """And the IFD that carries the tag is otherwise unaffected: its tiles are at the offsets it stores."""
     tiff = await load_tiff(name, variant="tifffile")
     ifd = tiff.ifds[0]
     assert (ifd.image_height, ifd.image_width) == (256, 256)

--- a/python/tests/test_ifd_tag_values.py
+++ b/python/tests/test_ifd_tag_values.py
@@ -1,13 +1,7 @@
-"""Tags whose values are IFD offsets, which the Python layer used to refuse.
-
-`TagValue::Ifd` and `TagValue::IfdBig` were the only variants `PyValue` had no conversion for, so any
-file carrying such a tag raised `RuntimeError: Unsupported value type 'Ifd'` — and it raised while the
-directory was being read, before a caller could choose to ignore the tag. One tag made the whole file
-unopenable.
+"""Tags whose values are IFD offsets.
 
 The tag that matters in practice is 330, SubIFDs, which microscopy writers use for pyramid levels:
-typed IFD in a classic TIFF and IFD8 in a BigTIFF. The Rust core already parsed both and converts
-them to integers; only the binding declined.
+typed IFD in a classic TIFF and IFD8 in a BigTIFF.
 """
 
 import numpy as np

--- a/python/tests/test_ifd_tag_values.py
+++ b/python/tests/test_ifd_tag_values.py
@@ -56,6 +56,25 @@ async def test_subifds_tag_reads_as_offsets(tmp_path, bigtiff, expected_type):
     assert all(0 < offset < path.stat().st_size for offset in offsets)
 
 
+async def test_subifds_can_be_read_at_their_offsets(tmp_path):
+    """And the levels they point at are reachable, which is the reason to expose the tag.
+
+    `ifds` follows the top-level chain, which SubIFDs are not part of, so a pyramid written that way
+    is invisible to a reader that only walks the chain -- one resolution out of however many.
+    """
+    path = tmp_path / "subifd_levels.tif"
+    write_with_subifd(path, bigtiff=False)
+
+    tiff = await TIFF.open(path.name, store=LocalStore(tmp_path))
+    assert len(tiff.ifds) == 1, "the reduced level is not in the top-level chain"
+
+    offsets = tiff.ifds[0].other_tags[SUBIFDS_TAG]
+    if isinstance(offsets, int):
+        offsets = [offsets]
+    reduced = await tiff.ifd_at(offsets[0])
+    assert (reduced.image_height, reduced.image_width) == (32, 32)
+
+
 async def test_the_image_beside_the_tag_still_reads(tmp_path):
     """And the IFD carrying the tag is otherwise unaffected: its own tiles are where it says."""
     path = tmp_path / "subifd_pixels.tif"

--- a/python/tests/test_tiff.py
+++ b/python/tests/test_tiff.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
+from rasterio.errors import NotGeoreferencedWarning
+from rasterio.plot import reshape_as_image
 from rasterio.windows import Window
 
 if TYPE_CHECKING:
@@ -53,3 +55,28 @@ async def test_header_byte_size(
         if offset != 0
     )
     assert header == expected
+
+
+@pytest.mark.asyncio
+async def test_first_ifd_at_the_end_of_the_file(
+    load_tiff: LoadTIFF,
+    load_rasterio: LoadRasterio,
+) -> None:
+    """A streaming writer's directory follows the image data instead of the header."""
+    tiff = await load_tiff("trailing_directory", variant="tifffile")
+    ifd = tiff.ifds[0]
+    assert (ifd.image_height, ifd.image_width) == (256, 256)
+
+    tile = await ifd.fetch_tile(0, 0)
+    array = await tile.decode()
+    data = np.array(array)
+
+    window = Window(0, 0, ifd.tile_width, ifd.tile_height)
+    # The fixture carries no georeferencing, and rasterio says so.
+    with (
+        pytest.warns(NotGeoreferencedWarning),
+        load_rasterio("trailing_directory", variant="tifffile") as rasterio_ds,
+    ):
+        np.testing.assert_array_equal(
+            data, reshape_as_image(rasterio_ds.read(window=window))
+        )

--- a/python/tests/test_tiff.py
+++ b/python/tests/test_tiff.py
@@ -72,7 +72,7 @@ async def test_first_ifd_at_the_end_of_the_file(
     data = np.array(array)
 
     window = Window(0, 0, ifd.tile_width, ifd.tile_height)
-    # The fixture carries no georeferencing, and rasterio says so.
+    # The fixture carries no georeferencing, so rasterio warns.
     with (
         pytest.warns(NotGeoreferencedWarning),
         load_rasterio("trailing_directory", variant="tifffile") as rasterio_ds,

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -60,9 +60,6 @@ dev = [
     { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ruff" },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "tifffile", version = "2026.7.31", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -86,7 +83,6 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "rasterio", specifier = ">=1.4" },
     { name = "ruff", specifier = ">=0.15" },
-    { name = "tifffile", specifier = ">=2024.1.30" },
 ]
 
 [[package]]
@@ -2036,51 +2032,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
-]
-
-[[package]]
-name = "tifffile"
-version = "2025.5.10"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.11'",
-]
-dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/06/bd0a6097da704a7a7c34a94cfd771c3ea3c2f405dd214e790d22c93f6be1/tifffile-2025.5.10-py3-none-any.whl", hash = "sha256:e37147123c0542d67bc37ba5cdd67e12ea6fbe6e86c52bee037a9eb6a064e5ad", size = 226533, upload-time = "2025-05-10T19:22:27.279Z" },
-]
-
-[[package]]
-name = "tifffile"
-version = "2026.3.3"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.11.*'",
-]
-dependencies = [
-    { name = "numpy", marker = "python_full_version == '3.11.*'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
-]
-
-[[package]]
-name = "tifffile"
-version = "2026.7.31"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.12'",
-]
-dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/62/083288b8d6b9ecb2968e7573e60aa0694089e960e203934bc217169acf64/tifffile-2026.7.31.tar.gz", hash = "sha256:79b1f4b1aba3ef3e6b6f1691a32abb62f5d7383faa52a12771c695232ba40bee", size = 442177, upload-time = "2026-08-01T02:28:32.523Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/ed/75bf4d6ae6fec7233ef466f27dffc99f91fde53a31e69f02640b418317ec/tifffile-2026.7.31-py3-none-any.whl", hash = "sha256:81adfa08012be1c478f99b83cda2f529eef8620cfbdf94fc41eef6f1d7b47dc5", size = 271576, upload-time = "2026-08-01T02:28:31.068Z" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -60,6 +60,9 @@ dev = [
     { name = "rasterio", version = "1.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "rasterio", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "ruff" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "tifffile", version = "2026.7.31", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -83,6 +86,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3" },
     { name = "rasterio", specifier = ">=1.4" },
     { name = "ruff", specifier = ">=0.15" },
+    { name = "tifffile", specifier = ">=2024.1.30" },
 ]
 
 [[package]]
@@ -2032,6 +2036,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2025.5.10"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/06/bd0a6097da704a7a7c34a94cfd771c3ea3c2f405dd214e790d22c93f6be1/tifffile-2025.5.10-py3-none-any.whl", hash = "sha256:e37147123c0542d67bc37ba5cdd67e12ea6fbe6e86c52bee037a9eb6a064e5ad", size = 226533, upload-time = "2025-05-10T19:22:27.279Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version == '3.11.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/e4/e804505f87627cd8cdae9c010c47c4485fd8c1ce31a7dd0ab7fcc4707377/tifffile-2026.3.3-py3-none-any.whl", hash = "sha256:e8be15c94273113d31ecb7aa3a39822189dd11c4967e3cc88c178f1ad2fd1170", size = 243960, upload-time = "2026-03-03T19:14:35.808Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.7.31"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/62/083288b8d6b9ecb2968e7573e60aa0694089e960e203934bc217169acf64/tifffile-2026.7.31.tar.gz", hash = "sha256:79b1f4b1aba3ef3e6b6f1691a32abb62f5d7383faa52a12771c695232ba40bee", size = 442177, upload-time = "2026-08-01T02:28:32.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/ed/75bf4d6ae6fec7233ef466f27dffc99f91fde53a31e69f02640b418317ec/tifffile-2026.7.31-py3-none-any.whl", hash = "sha256:81adfa08012be1c478f99b83cda2f529eef8620cfbdf94fc41eef6f1d7b47dc5", size = 271576, upload-time = "2026-08-01T02:28:31.068Z" },
 ]
 
 [[package]]

--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -100,7 +100,7 @@ impl SequentialBlockCache {
 ///
 /// The sequential cache above is contiguous from zero, which cannot describe a read far into the
 /// file. This holds a single window instead, replaced whenever a request falls outside it.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct WindowCache {
     /// Where `buffer` begins in the file
     start: u64,
@@ -108,13 +108,6 @@ struct WindowCache {
 }
 
 impl WindowCache {
-    fn new() -> Self {
-        Self {
-            start: 0,
-            buffer: Bytes::new(),
-        }
-    }
-
     fn contains(&self, range: &Range<u64>) -> bool {
         !self.buffer.is_empty()
             && range.start >= self.start
@@ -146,7 +139,7 @@ impl<F: MetadataFetch> ReadaheadMetadataCache<F> {
         Self {
             inner,
             cache: Arc::new(Mutex::new(SequentialBlockCache::new())),
-            window: Arc::new(Mutex::new(WindowCache::new())),
+            window: Arc::new(Mutex::new(WindowCache::default())),
             initial: 32 * 1024,
             multiplier: 2.0,
         }

--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -164,10 +164,10 @@ impl<F: MetadataFetch> ReadaheadMetadataCache<F> {
 
     /// Fetch a range that lies far beyond the sequential cache, through the window.
     ///
-    /// Reads here are as small as a single tag entry, so fetching exactly what is asked would put a
-    /// request on the wire for every one of them -- thousands, for an image with thousands of tiles.
-    /// The window is filled with at least `initial` bytes so that the reads following a miss are
-    /// served from memory, the same bargain the sequential cache makes at the front of the file.
+    /// Reads here are as small as a single tag entry, so a fetch of exactly what is asked would
+    /// send one request per entry — thousands, for an image with thousands of tiles. The window is
+    /// filled with at least `initial` bytes so that the reads after a miss come from memory, for
+    /// the same reason the sequential cache reads ahead at the front of the file.
     async fn fetch_distant(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
         let mut window = self.window.lock().await;
         if window.contains(&range) {
@@ -284,8 +284,8 @@ mod test {
         let data = Bytes::from(data);
         let fetch = TestFetch::new(data.clone());
         let counter = fetch.num_fetches.clone();
-        // 8 bytes would make a window too small to serve the reads that follow it, which is the
-        // point of having one: the default is 32 KiB.
+        // A 64-byte window is large enough for the reads below and far smaller than the
+        // 32 KiB default, so the test does not depend on that default.
         let cache = ReadaheadMetadataCache::new(fetch).with_initial_size(64);
 
         // A header read at the front, as a reader does first.

--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -96,12 +96,46 @@ impl SequentialBlockCache {
     }
 }
 
+/// Logic for managing one cached window at an arbitrary offset
+///
+/// The sequential cache above is contiguous from zero, which cannot describe a read far into the
+/// file. This holds a single window instead, replaced whenever a request falls outside it.
+#[derive(Debug)]
+struct WindowCache {
+    /// Where `buffer` begins in the file
+    start: u64,
+    buffer: Bytes,
+}
+
+impl WindowCache {
+    fn new() -> Self {
+        Self {
+            start: 0,
+            buffer: Bytes::new(),
+        }
+    }
+
+    fn contains(&self, range: &Range<u64>) -> bool {
+        !self.buffer.is_empty()
+            && range.start >= self.start
+            && range.end <= self.start + self.buffer.len() as u64
+    }
+
+    fn slice(&self, range: Range<u64>) -> Bytes {
+        let from = (range.start - self.start) as usize;
+        let to = (range.end - self.start) as usize;
+        self.buffer.slice(from..to)
+    }
+}
+
 /// A MetadataFetch implementation that caches fetched data in exponentially growing chunks,
 /// sequentially from the beginning of the file.
 #[derive(Debug)]
 pub struct ReadaheadMetadataCache<F: MetadataFetch> {
     inner: F,
     cache: Arc<Mutex<SequentialBlockCache>>,
+    /// For ranges the sequential cache cannot reach without fetching everything before them
+    window: Arc<Mutex<WindowCache>>,
     initial: u64,
     multiplier: f64,
 }
@@ -112,6 +146,7 @@ impl<F: MetadataFetch> ReadaheadMetadataCache<F> {
         Self {
             inner,
             cache: Arc::new(Mutex::new(SequentialBlockCache::new())),
+            window: Arc::new(Mutex::new(WindowCache::new())),
             initial: 32 * 1024,
             multiplier: 2.0,
         }
@@ -132,6 +167,34 @@ impl<F: MetadataFetch> ReadaheadMetadataCache<F> {
     pub fn with_multiplier(mut self, multiplier: f64) -> Self {
         self.multiplier = multiplier;
         self
+    }
+
+    /// Fetch a range that lies far beyond the sequential cache, through the window.
+    ///
+    /// Reads here are as small as a single tag entry, so fetching exactly what is asked would put a
+    /// request on the wire for every one of them -- thousands, for an image with thousands of tiles.
+    /// The window is filled with at least `initial` bytes so that the reads following a miss are
+    /// served from memory, the same bargain the sequential cache makes at the front of the file.
+    async fn fetch_distant(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
+        let mut window = self.window.lock().await;
+        if window.contains(&range) {
+            return Ok(window.slice(range));
+        }
+
+        let wanted = (range.end - range.start).max(self.initial);
+        let bytes = self.inner.fetch(range.start..range.start + wanted).await?;
+
+        // A window at the end of the file comes back short, which is expected: a store clamps the
+        // range to the object. It is only a problem if it fails to cover what was asked for.
+        if (bytes.len() as u64) < range.end - range.start {
+            return self.inner.fetch(range).await;
+        }
+
+        *window = WindowCache {
+            start: range.start,
+            buffer: bytes,
+        };
+        Ok(window.slice(range))
     }
 
     fn next_fetch_size(&self, existing_len: u64) -> u64 {
@@ -156,8 +219,21 @@ impl<F: MetadataFetch + Send + Sync> MetadataFetch for ReadaheadMetadataCache<F>
 
         // Compute the correct fetch range
         let start_len = cache.len;
+        let readahead = self.next_fetch_size(start_len);
+
+        // A range far beyond what is cached means the metadata is not near the front of the file.
+        // Writers that stream image data put their IFDs after it, so the first IFD of a 17 GB image
+        // can sit in its last kilobytes. Growing the sequential cache to reach it would fetch
+        // everything in between -- the whole file -- as one request, which fails or hangs rather
+        // than being merely wasteful. Read such a range where it is, and leave the cache alone: it
+        // is contiguous from zero by construction, and the bytes in between are never wanted.
+        if range.start > start_len + readahead {
+            drop(cache);
+            return self.fetch_distant(range).await;
+        }
+
         let needed = range.end.saturating_sub(start_len);
-        let fetch_size = self.next_fetch_size(start_len).max(needed);
+        let fetch_size = readahead.max(needed);
         let fetch_range = start_len..start_len + fetch_size;
 
         // Perform the fetch while holding mutex
@@ -205,6 +281,35 @@ mod test {
             *g += 1;
             Ok(slice)
         }
+    }
+
+    #[tokio::test]
+    async fn test_metadata_far_from_the_start_is_not_reached_by_fetching_everything_before_it() {
+        // A file whose metadata sits at the end, as TIFF writers that stream image data produce.
+        let mut data = vec![b'.'; 4096];
+        data.extend_from_slice(b"metadata-at-the-end");
+        let data = Bytes::from(data);
+        let fetch = TestFetch::new(data.clone());
+        let counter = fetch.num_fetches.clone();
+        // 8 bytes would make a window too small to serve the reads that follow it, which is the
+        // point of having one: the default is 32 KiB.
+        let cache = ReadaheadMetadataCache::new(fetch).with_initial_size(64);
+
+        // A header read at the front, as a reader does first.
+        assert_eq!(cache.fetch(0..4).await.unwrap(), data.slice(0..4));
+
+        // Then a read at the end. The sequential cache would have to fetch the 4 KiB in between.
+        let tail = cache.fetch(4096..4103).await.unwrap();
+        assert_eq!(tail, data.slice(4096..4103));
+
+        // And the reads that follow it come from the window rather than the wire.
+        let fetches_after_the_jump = *counter.lock().await;
+        assert_eq!(cache.fetch(4103..4108).await.unwrap(), data.slice(4103..4108));
+        assert_eq!(
+            *counter.lock().await,
+            fetches_after_the_jump,
+            "a read inside the window should not fetch again"
+        );
     }
 
     #[tokio::test]

--- a/src/metadata/cache.rs
+++ b/src/metadata/cache.rs
@@ -297,7 +297,10 @@ mod test {
 
         // And the reads that follow it come from the window rather than the wire.
         let fetches_after_the_jump = *counter.lock().await;
-        assert_eq!(cache.fetch(4103..4108).await.unwrap(), data.slice(4103..4108));
+        assert_eq!(
+            cache.fetch(4103..4108).await.unwrap(),
+            data.slice(4103..4108)
+        );
         assert_eq!(
             *counter.lock().await,
             fetches_after_the_jump,

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -126,10 +126,10 @@ impl TiffMetadataReader {
 
     /// Read a single IFD at a given byte offset.
     ///
-    /// The top-level chain is not the whole story: the spec allows IFDs anywhere in the file, and
-    /// SubIFDs (tag 330) are exactly that — offsets to directories outside the chain, which
-    /// [`read_all_ifds`][Self::read_all_ifds] therefore never reaches. Pyramid levels are commonly
-    /// written that way, so a reader that only follows the chain sees one resolution.
+    /// The spec allows an IFD at any offset in the file. SubIFDs (tag 330) are offsets to
+    /// directories outside the top-level chain, so [`read_all_ifds`][Self::read_all_ifds] never
+    /// reaches them. Pyramid levels are commonly written that way, so a reader that only follows
+    /// the chain sees one resolution level.
     pub async fn read_ifd_at<F: MetadataFetch>(
         &self,
         fetch: &F,

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -124,6 +124,22 @@ impl TiffMetadataReader {
         }
     }
 
+    /// Read a single IFD at a given byte offset.
+    ///
+    /// The top-level chain is not the whole story: the spec allows IFDs anywhere in the file, and
+    /// SubIFDs (tag 330) are exactly that — offsets to directories outside the chain, which
+    /// [`read_all_ifds`][Self::read_all_ifds] therefore never reaches. Pyramid levels are commonly
+    /// written that way, so a reader that only follows the chain sees one resolution.
+    pub async fn read_ifd_at<F: MetadataFetch>(
+        &self,
+        fetch: &F,
+        offset: u64,
+    ) -> AsyncTiffResult<ImageFileDirectory> {
+        let ifd_reader =
+            ImageFileDirectoryReader::open(fetch, offset, self.bigtiff, self.endianness).await?;
+        ifd_reader.read(fetch).await
+    }
+
     /// Read all IFDs from the file.
     pub async fn read_all_ifds<F: MetadataFetch>(
         &mut self,

--- a/src/test/geotiff_test_data/mod.rs
+++ b/src/test/geotiff_test_data/mod.rs
@@ -2,3 +2,4 @@
 
 mod rasterio_generated;
 mod real_data;
+mod tifffile_generated;

--- a/src/test/geotiff_test_data/tifffile_generated/mod.rs
+++ b/src/test/geotiff_test_data/tifffile_generated/mod.rs
@@ -1,0 +1,2 @@
+mod subifd_pyramid;
+mod trailing_directory;

--- a/src/test/geotiff_test_data/tifffile_generated/subifd_pyramid.rs
+++ b/src/test/geotiff_test_data/tifffile_generated/subifd_pyramid.rs
@@ -1,0 +1,61 @@
+//! Pyramids whose reduced resolutions are SubIFDs (tag 330), not top-level IFDs.
+
+use crate::metadata::TiffMetadataReader;
+use crate::tags::Tag;
+use crate::test::util::open_tiff;
+use crate::TagValue;
+
+const SUBIFDS: Tag = Tag::Unknown(330);
+
+/// Tag 330 holds one offset per reduced level, as plain integers.
+fn subifd_offsets(value: &TagValue) -> Vec<u64> {
+    let as_offset = |v: &TagValue| match v {
+        TagValue::Ifd(offset) => *offset as u64,
+        TagValue::IfdBig(offset) => *offset,
+        other => panic!("not an IFD offset: {other:?}"),
+    };
+    match value {
+        TagValue::List(values) => values.iter().map(as_offset).collect(),
+        single => vec![as_offset(single)],
+    }
+}
+
+async fn assert_pyramid(filename: &str) {
+    let (reader, tiff) = open_tiff(filename).await;
+
+    // The reduced levels are not in the top-level chain.
+    assert_eq!(tiff.ifds().len(), 1);
+    let full = &tiff.ifds()[0];
+    assert_eq!(full.image_height(), 256);
+    assert_eq!(full.image_width(), 256);
+    assert_eq!(full.tile_height(), Some(64));
+
+    let offsets = subifd_offsets(&full.other_tags()[&SUBIFDS]);
+    assert_eq!(offsets.len(), 2);
+
+    // They are where the tag says: one IFD per level, each half the size of the one before.
+    let metadata_reader = TiffMetadataReader::try_open(&reader).await.unwrap();
+    for (offset, expected_size) in offsets.into_iter().zip([128, 64]) {
+        let level = metadata_reader.read_ifd_at(&reader, offset).await.unwrap();
+        assert_eq!(level.image_height(), expected_size);
+        assert_eq!(level.image_width(), expected_size);
+
+        let tile = level.fetch_tile(0, 0, &reader).await.unwrap();
+        let array = tile.decode(&Default::default()).unwrap();
+        assert_eq!(array.shape, [64, 64, 1]);
+    }
+}
+
+/// In a classic TIFF the tag is typed IFD.
+#[tokio::test]
+async fn test_classic() {
+    assert_pyramid("geotiff-test-data/tifffile_generated/fixtures/subifd_pyramid_classic.tif")
+        .await;
+}
+
+/// In a BigTIFF the tag is typed IFD8.
+#[tokio::test]
+async fn test_bigtiff() {
+    assert_pyramid("geotiff-test-data/tifffile_generated/fixtures/subifd_pyramid_bigtiff.tif")
+        .await;
+}

--- a/src/test/geotiff_test_data/tifffile_generated/subifd_pyramid.rs
+++ b/src/test/geotiff_test_data/tifffile_generated/subifd_pyramid.rs
@@ -33,7 +33,7 @@ async fn assert_pyramid(filename: &str) {
     let offsets = subifd_offsets(&full.other_tags()[&SUBIFDS]);
     assert_eq!(offsets.len(), 2);
 
-    // They are where the tag says: one IFD per level, each half the size of the one before.
+    // The offsets point at real IFDs: one per level, each half the size of the previous level.
     let metadata_reader = TiffMetadataReader::try_open(&reader).await.unwrap();
     for (offset, expected_size) in offsets.into_iter().zip([128, 64]) {
         let level = metadata_reader.read_ifd_at(&reader, offset).await.unwrap();

--- a/src/test/geotiff_test_data/tifffile_generated/trailing_directory.rs
+++ b/src/test/geotiff_test_data/tifffile_generated/trailing_directory.rs
@@ -19,8 +19,8 @@ async fn test_trailing_directory() {
     let reader =
         Arc::new(ObjectReader::new(store, path.as_str().into())) as Arc<dyn AsyncFileReader>;
 
-    // The directory sits past the default 32 KiB window, so reading it takes the jump
-    // rather than the sequential growth path.
+    // The directory sits past the default 32 KiB window, so the read uses the window fetch
+    // path rather than the sequential growth path.
     let cache = ReadaheadMetadataCache::new(reader.clone());
     let mut metadata_reader = TiffMetadataReader::try_open(&cache).await.unwrap();
     let tiff = metadata_reader.read(&cache).await.unwrap();

--- a/src/test/geotiff_test_data/tifffile_generated/trailing_directory.rs
+++ b/src/test/geotiff_test_data/tifffile_generated/trailing_directory.rs
@@ -1,0 +1,37 @@
+//! A file whose first IFD is at the end, as streaming writers produce.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use object_store::local::LocalFileSystem;
+
+use crate::metadata::cache::ReadaheadMetadataCache;
+use crate::metadata::TiffMetadataReader;
+use crate::reader::{AsyncFileReader, ObjectReader};
+
+const FILENAME: &str = "geotiff-test-data/tifffile_generated/fixtures/trailing_directory.tif";
+
+#[tokio::test]
+async fn test_trailing_directory() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let store = Arc::new(LocalFileSystem::new_with_prefix(&manifest_dir).unwrap());
+    let path = format!("fixtures/{FILENAME}");
+    let reader =
+        Arc::new(ObjectReader::new(store, path.as_str().into())) as Arc<dyn AsyncFileReader>;
+
+    // The directory sits past the default 32 KiB window, so reading it takes the jump
+    // rather than the sequential growth path.
+    let cache = ReadaheadMetadataCache::new(reader.clone());
+    let mut metadata_reader = TiffMetadataReader::try_open(&cache).await.unwrap();
+    let tiff = metadata_reader.read(&cache).await.unwrap();
+
+    assert_eq!(tiff.ifds().len(), 1);
+    let ifd = &tiff.ifds()[0];
+    assert_eq!(ifd.image_height(), 256);
+    assert_eq!(ifd.image_width(), 256);
+    assert_eq!(ifd.tile_height(), Some(64));
+
+    let tile = ifd.fetch_tile(0, 0, &reader).await.unwrap();
+    let array = tile.decode(&Default::default()).unwrap();
+    assert_eq!(array.shape, [64, 64, 1]);
+}


### PR DESCRIPTION
- Parse and return IFD tags to Python, instead of erroring.
- Add a function to read IFD from an arbitrary location. This is needed to read SubIFDs, allowing reading a level directly, without parsing the top-level of the pyramid. This also required changes to read the arbitrary location because the sequential cache that already exists tried to parse the whole file, and sometimes the SubIFD is located at the end of a potentially large file.
 
PR needed for https://github.com/virtual-zarr/virtual-tiff/pull/107

Blocked on
- [x] https://github.com/developmentseed/geotiff-test-data/pull/66 being merged
- [x] reverting the submodule change from ☝️ PR to `main` again