### PR TITLE
chore: fix clippy lints from Rust 1.98

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "async-tiff"
 version = "0.3.0"
 edition = "2021"
+rust-version = "1.88"
 authors = ["Kyle Barron <kyle@developmentseed.org>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/developmentseed/async-tiff"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1132,9 +1132,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243cb2271683c2855cad62142cbf38199db439b1b1e1ccdd5a011342894dd7cc"
+checksum = "5c1bf3331fb5cf60f2ef15b63361f6cc39492a5d94c096053c395515e17d147f"
 dependencies = [
  "sha2",
 ]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/developmentseed/async-tiff"
 license = "MIT OR Apache-2.0"
 keywords = ["python", "geospatial"]
 categories = ["science::geo"]
-rust-version = "1.75"
+rust-version = "1.89"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/src/array.rs
+++ b/src/array.rs
@@ -160,8 +160,11 @@ impl TypedArray {
                 Ok(TypedArray::UInt16(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(2)
-                            .map(|b| u16::from_ne_bytes([b[0], b[1]]))
+                        data.as_chunks::<2>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(u16::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -176,8 +179,11 @@ impl TypedArray {
                 Ok(TypedArray::UInt32(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(4)
-                            .map(|b| u32::from_ne_bytes([b[0], b[1], b[2], b[3]]))
+                        data.as_chunks::<4>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(u32::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -192,10 +198,11 @@ impl TypedArray {
                 Ok(TypedArray::UInt64(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(8)
-                            .map(|b| {
-                                u64::from_ne_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
-                            })
+                        data.as_chunks::<8>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(u64::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -212,8 +219,11 @@ impl TypedArray {
                 Ok(TypedArray::Int16(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(2)
-                            .map(|b| i16::from_ne_bytes([b[0], b[1]]))
+                        data.as_chunks::<2>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(i16::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -228,8 +238,11 @@ impl TypedArray {
                 Ok(TypedArray::Int32(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(4)
-                            .map(|b| i32::from_ne_bytes([b[0], b[1], b[2], b[3]]))
+                        data.as_chunks::<4>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(i32::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -244,10 +257,11 @@ impl TypedArray {
                 Ok(TypedArray::Int64(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(8)
-                            .map(|b| {
-                                i64::from_ne_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
-                            })
+                        data.as_chunks::<8>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(i64::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -262,8 +276,11 @@ impl TypedArray {
                 Ok(TypedArray::Float32(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(4)
-                            .map(|b| f32::from_ne_bytes([b[0], b[1], b[2], b[3]]))
+                        data.as_chunks::<4>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(f32::from_ne_bytes)
                             .collect()
                     },
                 )))
@@ -278,10 +295,11 @@ impl TypedArray {
                 Ok(TypedArray::Float64(try_cast_vec(data).unwrap_or_else(
                     |(_, data)| {
                         // Fallback to manual conversion when not aligned
-                        data.chunks_exact(8)
-                            .map(|b| {
-                                f64::from_ne_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]])
-                            })
+                        data.as_chunks::<8>()
+                            .0
+                            .iter()
+                            .copied()
+                            .map(f64::from_ne_bytes)
                             .collect()
                     },
                 )))

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -306,7 +306,7 @@ impl Decoder for WebPDecoder {
         // Only do this for 8-bit data since WebP only supports 8-bit.
         if samples_per_pixel == 4 && bits_per_sample == 8 && !decoded.is_alpha() {
             let mut rgba = Vec::with_capacity(data.len() / 3 * 4);
-            for chunk in data.chunks_exact(3) {
+            for chunk in data.as_chunks::<3>().0 {
                 rgba.extend_from_slice(chunk);
                 rgba.push(255); // opaque alpha
             }

--- a/src/predictor.rs
+++ b/src/predictor.rs
@@ -20,27 +20,39 @@ pub(crate) fn fix_endianness(buffer: &mut [u8], byte_order: Endianness, bits_per
     match byte_order {
         Endianness::LittleEndian => match bits_per_sample {
             0..=8 => {}
-            9..=16 => buffer.chunks_exact_mut(2).for_each(|v| {
-                v.copy_from_slice(&u16::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
-            17..=32 => buffer.chunks_exact_mut(4).for_each(|v| {
-                v.copy_from_slice(&u32::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
-            _ => buffer.chunks_exact_mut(8).for_each(|v| {
-                v.copy_from_slice(&u64::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
+            9..=16 => buffer
+                .as_chunks_mut::<2>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u16::from_le_bytes(*v).to_ne_bytes()),
+            17..=32 => buffer
+                .as_chunks_mut::<4>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u32::from_le_bytes(*v).to_ne_bytes()),
+            _ => buffer
+                .as_chunks_mut::<8>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u64::from_le_bytes(*v).to_ne_bytes()),
         },
         Endianness::BigEndian => match bits_per_sample {
             0..=8 => {}
-            9..=16 => buffer.chunks_exact_mut(2).for_each(|v| {
-                v.copy_from_slice(&u16::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
-            17..=32 => buffer.chunks_exact_mut(4).for_each(|v| {
-                v.copy_from_slice(&u32::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
-            _ => buffer.chunks_exact_mut(8).for_each(|v| {
-                v.copy_from_slice(&u64::from_be_bytes((*v).try_into().unwrap()).to_ne_bytes())
-            }),
+            9..=16 => buffer
+                .as_chunks_mut::<2>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u16::from_be_bytes(*v).to_ne_bytes()),
+            17..=32 => buffer
+                .as_chunks_mut::<4>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u32::from_be_bytes(*v).to_ne_bytes()),
+            _ => buffer
+                .as_chunks_mut::<8>()
+                .0
+                .iter_mut()
+                .for_each(|v| *v = u64::from_be_bytes(*v).to_ne_bytes()),
         },
     }
 }
@@ -145,11 +157,8 @@ fn rev_predict_f16(input: &mut [u8], output: &mut [u8], samples: usize) {
     for i in samples..input.len() {
         input[i] = input[i].wrapping_add(input[i - samples]);
     }
-    for (i, chunk) in output.chunks_exact_mut(2).enumerate() {
-        chunk.copy_from_slice(&u16::to_ne_bytes(u16::from_be_bytes([
-            input[i],
-            input[input.len() / 2 + i],
-        ])));
+    for (i, chunk) in output.as_chunks_mut::<2>().0.iter_mut().enumerate() {
+        *chunk = u16::from_be_bytes([input[i], input[input.len() / 2 + i]]).to_ne_bytes();
     }
 }
 
@@ -157,13 +166,14 @@ fn rev_predict_f32(input: &mut [u8], output: &mut [u8], samples: usize) {
     for i in samples..input.len() {
         input[i] = input[i].wrapping_add(input[i - samples]);
     }
-    for (i, chunk) in output.chunks_exact_mut(4).enumerate() {
-        chunk.copy_from_slice(&u32::to_ne_bytes(u32::from_be_bytes([
+    for (i, chunk) in output.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        *chunk = u32::from_be_bytes([
             input[i],
             input[input.len() / 4 + i],
             input[input.len() / 4 * 2 + i],
             input[input.len() / 4 * 3 + i],
-        ])));
+        ])
+        .to_ne_bytes();
     }
 }
 
@@ -171,8 +181,8 @@ fn rev_predict_f64(input: &mut [u8], output: &mut [u8], samples: usize) {
     for i in samples..input.len() {
         input[i] = input[i].wrapping_add(input[i - samples]);
     }
-    for (i, chunk) in output.chunks_exact_mut(8).enumerate() {
-        chunk.copy_from_slice(&u64::to_ne_bytes(u64::from_be_bytes([
+    for (i, chunk) in output.as_chunks_mut::<8>().0.iter_mut().enumerate() {
+        *chunk = u64::from_be_bytes([
             input[i],
             input[input.len() / 8 + i],
             input[input.len() / 8 * 2 + i],
@@ -181,6 +191,7 @@ fn rev_predict_f64(input: &mut [u8], output: &mut [u8], samples: usize) {
             input[input.len() / 8 * 5 + i],
             input[input.len() / 8 * 6 + i],
             input[input.len() / 8 * 7 + i],
-        ])));
+        ])
+        .to_ne_bytes();
     }
 }


### PR DESCRIPTION
## Problem

The `clippy_check` job in [Lint](.github/workflows/lint.yml) is failing on every open PR (e.g. #335), with 18 errors that have nothing to do with the PRs' contents:

```
error: using `chunks_exact` with a constant chunk size
   --> src/array.rs:163:30
    |
163 |                         data.chunks_exact(2)
    |                              ^^^^^^^^^^^^^^^^ help: consider using `as_chunks` instead: `as_chunks::<2>().0.iter()`
```

`clippy::chunks_exact_to_as_chunks` is new in Rust 1.98. The `clippy_check` job has no toolchain-install step, so it picks up whatever Rust the runner image ships — meaning this broke with no code change on our side.

## Commit 1 — fix the lint

Replace `chunks_exact(N)` / `chunks_exact_mut(N)` with `as_chunks::<N>()` / `as_chunks_mut::<N>()` at all 18 sites (8 in `src/array.rs`, 1 in `src/decoder.rs`, 9 in `src/predictor.rs`).

Because these yield `[u8; N]` rather than `&[u8]`, the array length is known statically, which lets a few things drop out:

- `src/predictor.rs` — `fix_endianness` loses its `(*v).try_into().unwrap()`:
  ```rust
  9..=16 => buffer.chunks_exact_mut(2).for_each(|v| {
      v.copy_from_slice(&u16::from_le_bytes((*v).try_into().unwrap()).to_ne_bytes())
  }),
  // becomes
  9..=16 => buffer
      .as_chunks_mut::<2>()
      .0
      .iter_mut()
      .for_each(|v| *v = u16::from_le_bytes(*v).to_ne_bytes()),
  ```
- `src/array.rs` — the fallback closures lose their manual indexing:
  ```rust
  data.chunks_exact(2).map(|b| u16::from_ne_bytes([b[0], b[1]])).collect()
  // becomes
  data.as_chunks::<2>().0.iter().copied().map(u16::from_ne_bytes).collect()
  ```

No behavior change: `as_chunks::<N>().0` covers exactly the same elements as `chunks_exact(N)` and discards the same remainder.

## Commit 2 — declare accurate MSRVs

`slice::as_chunks` is stable since 1.88, so commit 1 sets a hard floor. The manifests did not reflect reality:

| Crate | Before | After |
| --- | --- | --- |
| `async-tiff` | *(no `rust-version`)* | `1.88` |
| `py-async-tiff` | `1.75` | `1.89` |

`py-async-tiff` gets 1.89 rather than 1.88 because its committed `Cargo.lock` pins `crc-fast` 1.10.0, which itself requires 1.89 — 1.88 genuinely does not resolve there:

```
error: rustc 1.88.0 is not supported by the following package:
  crc-fast@1.10.0 requires rustc 1.89
```

The old `1.75` had been wrong for a while regardless — `src/array.rs` uses `usize::is_multiple_of`, stable in 1.87.

## Verification

Against Rust 1.98.0 (matching the CI runner), with `RUSTFLAGS=-Dwarnings`:

- `cargo clippy --all-targets --all-features` — clean
- `cargo clippy --all-targets --all-features --manifest-path python/Cargo.toml` — clean
- `cargo fmt --all --check` (both manifests, with the CI's `imports_granularity`/`group_imports` config) — clean
- `cargo test --all --all-features` — 56 passed, 0 failed, 2 ignored; 6 doc-tests passed
- `cargo doc --all-features --document-private-items` with `RUSTDOCFLAGS=-D warnings` — clean

Confirming the MSRV declarations, `cargo check --all-targets --all-features`:

- root crate on 1.88 — passes
- python crate on 1.89 — passes; on 1.88 — fails, as the new declaration says

Note that declaring a `rust-version` activates `clippy::incompatible_msrv` (warn-by-default, so an error under `-Dwarnings`). Both crates are clean under it — no APIs newer than the declared floors.

CI was green on commit 1 alone, including `clippy_check`.