### PR TITLE
fix: return errors instead of panicking on malformed TIFF metadata

### DIFF
--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -224,11 +224,19 @@ impl ImageFileDirectory {
                 Tag::MaxSampleValue => max_sample_value = Some(value.into_u16_vec()?),
                 Tag::XResolution => match value {
                     TagValue::Rational(n, d) => x_resolution = Some(n as f64 / d as f64),
-                    _ => unreachable!("Expected rational type for XResolution."),
+                    _ => {
+                        return Err(TiffError::FormatError(
+                            TiffFormatError::InvalidTagValueType(Tag::XResolution),
+                        ))
+                    }
                 },
                 Tag::YResolution => match value {
                     TagValue::Rational(n, d) => y_resolution = Some(n as f64 / d as f64),
-                    _ => unreachable!("Expected rational type for YResolution."),
+                    _ => {
+                        return Err(TiffError::FormatError(
+                            TiffFormatError::InvalidTagValueType(Tag::YResolution),
+                        ))
+                    }
                 },
                 Tag::PlanarConfiguration => {
                     planar_configuration = PlanarConfiguration::from_u16(value.into_u16()?)
@@ -299,12 +307,19 @@ impl ImageFileDirectory {
 
             let header = chunks
                 .next()
-                .expect("If the geo key directory exists, a header should exist.");
+                .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
+            if header.len() < 4 {
+                return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
+            }
             let key_directory_version = header[0];
-            assert_eq!(key_directory_version, 1);
+            if key_directory_version != 1 {
+                return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
+            }
 
             let key_revision = header[1];
-            assert_eq!(key_revision, 1);
+            if key_revision != 1 {
+                return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
+            }
 
             let _key_minor_revision = header[2];
             let number_of_keys = header[3];
@@ -313,7 +328,10 @@ impl ImageFileDirectory {
             for _ in 0..number_of_keys {
                 let chunk = chunks
                     .next()
-                    .expect("There should be a chunk for each key.");
+                    .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
+                if chunk.len() < 4 {
+                    return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
+                }
 
                 let key_id = chunk[0];
                 let tag_name = if let Ok(tag_name) = GeoKeyTag::try_from_primitive(key_id) {
@@ -338,9 +356,14 @@ impl ImageFileDirectory {
 
                     let geo_ascii_params = geo_ascii_params
                         .as_ref()
-                        .expect("GeoAsciiParamsTag exists but geo_ascii_params does not.");
+                        .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
                     let value_offset = value_offset as usize;
-                    let mut s = &geo_ascii_params[value_offset..value_offset + count as usize];
+                    let end = value_offset
+                        .checked_add(count as usize)
+                        .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
+                    let mut s = geo_ascii_params
+                        .get(value_offset..end)
+                        .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
 
                     // It seems that this string subslice might always include the final |
                     // character?
@@ -355,12 +378,21 @@ impl ImageFileDirectory {
 
                     let geo_double_params = geo_double_params
                         .as_ref()
-                        .expect("GeoDoubleParamsTag exists but geo_double_params does not.");
+                        .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
                     let value_offset = value_offset as usize;
                     let value = if count == 1 {
-                        TagValue::Double(geo_double_params[value_offset])
+                        TagValue::Double(
+                            *geo_double_params
+                                .get(value_offset)
+                                .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?,
+                        )
                     } else {
-                        let x = geo_double_params[value_offset..value_offset + count as usize]
+                        let end = value_offset
+                            .checked_add(count as usize)
+                            .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?;
+                        let x = geo_double_params
+                            .get(value_offset..end)
+                            .ok_or(TiffError::FormatError(TiffFormatError::InvalidTag))?
                             .iter()
                             .map(|val| TagValue::Double(*val))
                             .collect();
@@ -372,7 +404,9 @@ impl ImageFileDirectory {
             geo_key_directory = Some(GeoKeyDirectory::from_tags(tags)?);
         }
 
-        let samples_per_pixel = samples_per_pixel.expect("samples_per_pixel not found");
+        let samples_per_pixel = samples_per_pixel.ok_or(TiffError::FormatError(
+            TiffFormatError::RequiredTagNotFound(Tag::SamplesPerPixel),
+        ))?;
         let planar_configuration = if let Some(planar_configuration) = planar_configuration {
             planar_configuration
         } else if samples_per_pixel == 1 {
@@ -385,14 +419,23 @@ impl ImageFileDirectory {
         Ok(Self {
             endianness,
             new_subfile_type,
-            image_width: image_width.expect("image_width not found"),
-            image_height: image_height.expect("image_height not found"),
-            bits_per_sample: bits_per_sample.expect("bits per sample not found"),
+            image_width: image_width.ok_or(TiffError::FormatError(
+                TiffFormatError::RequiredTagNotFound(Tag::ImageWidth),
+            ))?,
+            image_height: image_height.ok_or(TiffError::FormatError(
+                TiffFormatError::RequiredTagNotFound(Tag::ImageLength),
+            ))?,
+            bits_per_sample: bits_per_sample.ok_or(TiffError::FormatError(
+                TiffFormatError::RequiredTagNotFound(Tag::BitsPerSample),
+            ))?,
             // Defaults to no compression
             // https://web.archive.org/web/20240329145331/https://www.awaresystems.be/imaging/tiff/tifftags/compression.html
             compression: compression.unwrap_or(Compression::None),
-            photometric_interpretation: photometric_interpretation
-                .expect("photometric interpretation not found"),
+            photometric_interpretation: photometric_interpretation.ok_or(
+                TiffError::FormatError(TiffFormatError::RequiredTagNotFound(
+                    Tag::PhotometricInterpretation,
+                )),
+            )?,
             document_name,
             image_description,
             strip_offsets,

--- a/src/metadata/reader.rs
+++ b/src/metadata/reader.rs
@@ -11,6 +11,21 @@ use crate::tag_value::TagValue;
 use crate::tags::{Tag, Type};
 use crate::{ImageFileDirectory, TIFF};
 
+/// A tag's element `count` is read straight from the (untrusted) file, so it
+/// must not size an allocation on its own: a malformed tag can claim billions
+/// of elements and a matching `Vec::with_capacity` would abort the process
+/// before a single byte is read. Pre-allocate at most this many elements; the
+/// reading loop still grows the vector to hold whatever the file actually
+/// contains (and fails cleanly at EOF).
+const MAX_PREALLOC_ELEMENTS: u64 = 16 * 1024;
+
+/// Capacity to pre-allocate for a tag with `count` elements, bounded so an
+/// oversized `count` cannot drive an unbounded allocation.
+#[inline]
+fn prealloc_capacity(count: u64) -> usize {
+    count.min(MAX_PREALLOC_ELEMENTS) as usize
+}
+
 /// Entry point to reading TIFF metadata.
 ///
 /// This is a stateful reader because we don't know how many IFDs will be encountered.
@@ -271,9 +286,9 @@ async fn read_tag<F: MetadataFetch>(
     let tag_name = Tag::from_u16_exhaustive(cursor.read_u16().await?);
 
     let tag_type_code = cursor.read_u16().await?;
-    let tag_type = Type::from_u16(tag_type_code).expect(
-        "Unknown tag type {tag_type_code}. TODO: we should skip entries with unknown tag types.",
-    );
+    let tag_type = Type::from_u16(tag_type_code).ok_or(TiffError::FormatError(
+        TiffFormatError::InvalidTagValueType(tag_name),
+    ))?;
     let count = if bigtiff {
         cursor.read_u64().await?
     } else {
@@ -359,8 +374,7 @@ async fn read_tag_value<F: MetadataFetch>(
                 if data.as_ref()[0] == 0 {
                     TagValue::Ascii("".to_string())
                 } else {
-                    panic!("Invalid tag");
-                    // return Err(TiffError::FormatError(TiffFormatError::InvalidTag));
+                    return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
                 }
             }
             Type::LONG8 => {
@@ -430,7 +444,7 @@ async fn read_tag_value<F: MetadataFetch>(
                 }
             }
             Type::ASCII => {
-                let mut buf = vec![0; count as usize];
+                let mut buf = vec![0; prealloc_capacity(count)];
                 data.read_exact(&mut buf)?;
                 if buf.is_ascii() && buf.ends_with(&[0]) {
                     let v = std::str::from_utf8(&buf)
@@ -438,8 +452,7 @@ async fn read_tag_value<F: MetadataFetch>(
                     let v = v.trim_matches(char::from(0));
                     return Ok(TagValue::Ascii(v.into()));
                 } else {
-                    panic!("Invalid tag");
-                    // return Err(TiffError::FormatError(TiffFormatError::InvalidTag));
+                    return Err(TiffError::FormatError(TiffFormatError::InvalidTag).into());
                 }
             }
             Type::SHORT => {
@@ -508,63 +521,63 @@ async fn read_tag_value<F: MetadataFetch>(
         // TODO check if this could give wrong results
         // at a different endianess of file/computer.
         Type::BYTE | Type::UNDEFINED => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Byte(cursor.read_u8().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::SBYTE => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::SignedByte(cursor.read_i8().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::SHORT => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Short(cursor.read_u16().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::SSHORT => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::SignedShort(cursor.read_i16().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::LONG => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Unsigned(cursor.read_u32().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::SLONG => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Signed(cursor.read_i32().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::FLOAT => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Float(cursor.read_f32().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::DOUBLE => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Double(cursor.read_f64().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::RATIONAL => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Rational(
                     cursor.read_u32().await?,
@@ -574,7 +587,7 @@ async fn read_tag_value<F: MetadataFetch>(
             Ok(TagValue::List(v))
         }
         Type::SRATIONAL => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::SRational(
                     cursor.read_i32().await?,
@@ -584,36 +597,40 @@ async fn read_tag_value<F: MetadataFetch>(
             Ok(TagValue::List(v))
         }
         Type::LONG8 => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::UnsignedBig(cursor.read_u64().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::SLONG8 => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::SignedBig(cursor.read_i64().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::IFD => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::Ifd(cursor.read_u32().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::IFD8 => {
-            let mut v = Vec::with_capacity(count as _);
+            let mut v = Vec::with_capacity(prealloc_capacity(count));
             for _ in 0..count {
                 v.push(TagValue::IfdBig(cursor.read_u64().await?))
             }
             Ok(TagValue::List(v))
         }
         Type::ASCII => {
-            let mut out = vec![0; count as _];
-            let mut buf = cursor.read(count).await?;
+            let buf = cursor.read(count).await?;
+            // `count` is untrusted; size the output to the bytes actually
+            // fetched (the fetch layer clamps to what the file contains) rather
+            // than pre-allocating the claimed `count`.
+            let mut out = vec![0; buf.as_ref().len()];
+            let mut buf = buf;
             buf.read_exact(&mut out)?;
 
             // Strings may be null-terminated, so we trim anything downstream of the null byte

--- a/tests/malformed_input.rs
+++ b/tests/malformed_input.rs
@@ -1,0 +1,97 @@
+use std::ops::Range;
+use std::panic::AssertUnwindSafe;
+
+use async_tiff::error::AsyncTiffResult;
+use async_tiff::metadata::{MetadataFetch, TiffMetadataReader};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::FutureExt;
+
+// In-memory fetch over a byte buffer.
+#[derive(Debug)]
+struct MemFetch(Bytes);
+
+#[async_trait]
+impl MetadataFetch for MemFetch {
+    async fn fetch(&self, range: Range<u64>) -> AsyncTiffResult<Bytes> {
+        let start = range.start as usize;
+        let end = (range.end as usize).min(self.0.len());
+        let out = if start >= self.0.len() || start > end {
+            Bytes::new()
+        } else {
+            self.0.slice(start..end)
+        };
+        Ok(out)
+    }
+}
+
+async fn parse(data: Bytes) {
+    let fetch = MemFetch(data);
+    if let Ok(mut r) = TiffMetadataReader::try_open(&fetch).await {
+        let _ = r.read(&fetch).await;
+    }
+}
+
+#[tokio::test]
+async fn mutated_tiffs_never_panic() {
+    let paths = [
+        "fixtures/image-tiff/gradient-1c-32b.tiff",
+        "fixtures/image-tiff/palette-1c-1b.tiff",
+        "fixtures/image-tiff/quad-lzw-compat.tiff",
+        "fixtures/image-tiff/geo-5b.tif",
+        "fixtures/other/geogtowgs_subset_USGS_13_s14w171.tif",
+    ];
+    let mut seeds: Vec<Vec<u8>> = Vec::new();
+    for p in paths {
+        if let Ok(b) = std::fs::read(p) {
+            seeds.push(b);
+        }
+    }
+    assert!(!seeds.is_empty(), "no fixtures found");
+
+    let mut rng: u64 = 0x9e3779b97f4a7c15;
+    let mut next = || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+
+    for iter in 0..50_000u64 {
+        let seed = &seeds[(iter as usize) % seeds.len()];
+        let mut b = seed.clone();
+        let ops = next() % 6 + 1;
+        for _ in 0..ops {
+            if b.is_empty() {
+                break;
+            }
+            match next() % 4 {
+                0 => {
+                    let i = (next() as usize) % b.len();
+                    b[i] = (next() & 0xff) as u8;
+                }
+                1 => {
+                    let i = (next() as usize) % b.len();
+                    b[i] ^= 1 << (next() % 8);
+                }
+                2 => b.truncate((next() as usize) % b.len().max(1)),
+                _ => {
+                    // bump a byte in the IFD area (after the 8-byte header)
+                    if b.len() > 12 {
+                        let i = 8 + (next() as usize) % (b.len() - 8);
+                        b[i] = (next() & 0xff) as u8;
+                    }
+                }
+            }
+        }
+        let data = Bytes::from(b.clone());
+        let res = AssertUnwindSafe(parse(data)).catch_unwind().await;
+        if res.is_err() {
+            panic!(
+                "PANIC at iter {iter} on {} bytes: head={:02x?}",
+                b.len(),
+                &b[..b.len().min(32)]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## What

The IFD metadata parser assumes well-formed input in several spots and **panics** (or aborts via OOM) on a crafted or truncated TIFF instead of returning an error. Since `TiffMetadataReader` reads from untrusted sources (a remote object store, a user-supplied file), any of these turns a bad file into a process crash.

Found by mutating the in-repo fixtures and feeding them through `TiffMetadataReader::read`. Each fix reuses an error variant that already exists for exactly this case, so the reader returns `Err` instead of unwinding.

## The panics

- **Missing required tags.** `ImageWidth`, `ImageLength`, `BitsPerSample`, `PhotometricInterpretation`, `SamplesPerPixel` were unwrapped with `.expect("… not found")`. A file missing any of them panicked → now `RequiredTagNotFound(tag)`.
- **Unknown tag type code** hit `.expect("Unknown tag type … TODO: we should skip …")` → now `InvalidTagValueType(tag)`.
- **`XResolution` / `YResolution` with a non-rational value** hit `unreachable!()` → now `InvalidTagValueType(tag)`.
- **Invalid ASCII tag** hit `panic!("Invalid tag")` (the `Err` line was right there, commented out) → now `InvalidTag`.
- **Unbounded allocation.** A tag's element `count` comes straight from the file and was passed directly to `Vec::with_capacity(count)` / `vec![0; count]`. A tag claiming billions of elements aborted the process on the allocation before a single byte was read. Now the pre-allocation is bounded; the reading loop still grows the vector to hold whatever the file actually contains (and fails cleanly at EOF).
- **GeoKeyDirectory parser.** Its header and per-key chunks used `.expect()` / `assert_eq!`, and `GeoAsciiParams` / `GeoDoubleParams` were indexed with unchecked slices — all reachable from a malformed GeoTIFF. Now bounds-checked with `Err` on violation.

## Test

`tests/malformed_input.rs` mutates the in-repo fixtures (including two GeoTIFFs) and asserts the reader never panics. On `main` it aborts within the first few thousand iterations; with this change it runs clean. Existing tests still pass (the pre-existing failures in `test::geotiff_test_data::…` are the missing `geotiff-test-data` submodule fixtures, unrelated to this change).

No public API change — same functions, same signatures, just `Err` where they used to panic.

---
*Disclosure: patch prepared with AI assistance; every change was compiled, tested, and the fuzz reproduction verified locally before submitting.*
