### PR TITLE
feat: support sparse GeoTIFF tiles

### DIFF
--- a/python/python/async_tiff/_ifd.pyi
+++ b/python/python/async_tiff/_ifd.pyi
@@ -172,4 +172,15 @@ class ImageFileDirectory:
 
         This will be `None` if the IFD is not tiled.
         """
+    def is_tile_sparse(self, x: int, y: int) -> bool:
+        """Whether the tile at the given column and row is entirely sparse -- i.e. never
+        written by the encoder. `False` for a planar tile with only some bands sparse.
+
+        Args:
+            x: The column index within the ifd to check.
+            y: The row index within the ifd to check.
+
+        Raises:
+            ValueError: if the IFD is not tiled.
+        """
         ...

--- a/python/python/async_tiff/_tile.pyi
+++ b/python/python/async_tiff/_tile.pyi
@@ -14,15 +14,24 @@ class Tile:
     def y(self) -> int:
         """The row index this tile represents."""
     @property
-    def compressed_bytes(self) -> Buffer | list[Buffer]:
+    def compressed_bytes(self) -> Buffer | None | list[Buffer | None]:
         """The compressed bytes underlying this tile.
 
         This will be a single buffer for pixel-interleaved (chunky) data, or a list of
-        buffers for band-interleaved (planar) data.
+        buffers for band-interleaved (planar) data. A `None` entry means that tile or band
+        was never written by the encoder (sparse); see `is_sparse`.
         """
     @property
     def compression_method(self) -> Compression | int:
         """The compression method used by this tile."""
+    @property
+    def is_sparse(self) -> bool:
+        """Whether this tile is entirely sparse (never written by the encoder).
+
+        `False` for a planar tile with only some bands sparse; inspect
+        `compressed_bytes` for per-band detail in that case. `decode` still succeeds for a
+        sparse tile, filling it with the IFD's nodata value (or `0`).
+        """
     def decode_sync(
         self,
         *,

--- a/python/src/ifd.rs
+++ b/python/src/ifd.rs
@@ -496,6 +496,12 @@ impl PyImageFileDirectory {
         Ok(PyTileByteRange(byte_range))
     }
 
+    fn is_tile_sparse(&self, x: usize, y: usize) -> PyAsyncTiffResult<bool> {
+        self.ifd
+            .is_tile_sparse(x, y)
+            .ok_or(PyValueError::new_err("Not a tiled tiff").into())
+    }
+
     #[getter]
     fn tile_count(&self) -> Option<(usize, usize)> {
         self.ifd.tile_count()

--- a/python/src/tile.rs
+++ b/python/src/tile.rs
@@ -56,6 +56,14 @@ impl PyTile {
             .map(|t| t.compression_method().into())
     }
 
+    #[getter]
+    fn is_sparse(&self) -> PyResult<bool> {
+        self.0
+            .as_ref()
+            .ok_or(PyValueError::new_err("Tile has been consumed"))
+            .map(|t| t.is_sparse())
+    }
+
     fn decode_sync<'py>(
         &mut self,
         py: Python<'py>,
@@ -102,17 +110,22 @@ impl PyTile {
 
 #[derive(IntoPyObject)]
 enum PyCompressedBytes {
-    Chunky(PyBytes),
-    Planar(Vec<PyBytes>),
+    /// `None` if the tile is sparse (never written by the encoder).
+    Chunky(Option<PyBytes>),
+    /// `None` per band that's sparse.
+    Planar(Vec<Option<PyBytes>>),
 }
 
 impl From<CompressedBytes> for PyCompressedBytes {
     fn from(value: CompressedBytes) -> Self {
         match value {
-            CompressedBytes::Chunky(bytes) => PyCompressedBytes::Chunky(bytes.into()),
-            CompressedBytes::Planar(band_bytes) => {
-                PyCompressedBytes::Planar(band_bytes.into_iter().map(|b| b.into()).collect())
-            }
+            CompressedBytes::Chunky(bytes) => PyCompressedBytes::Chunky(bytes.map(|b| b.into())),
+            CompressedBytes::Planar(band_bytes) => PyCompressedBytes::Planar(
+                band_bytes
+                    .into_iter()
+                    .map(|b| b.map(|b| b.into()))
+                    .collect(),
+            ),
         }
     }
 }

--- a/python/tests/test_integration_rasterio.py
+++ b/python/tests/test_integration_rasterio.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
         # ("rasterio", "uint8_1band_jxl_block64"),
         ("rasterio", "uint8_1band_lzma_block64"),
         ("rasterio", "uint8_1band_lzw_block64_predictor2"),
+        ("rasterio", "uint8_1band_sparse_nodata"),
+        ("rasterio", "uint8_1band_sparse_no_nodata"),
         ("rasterio", "uint8_nonrgb_deflate_block64_cog"),
         ("rasterio", "uint8_rgb_deflate_block64_cog"),
         ("rasterio", "uint8_rgb_webp_block64_cog"),

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -729,6 +729,16 @@ impl ImageFileDirectory {
         TilesByteRanges::from_ifd_tiles(self, xy)
     }
 
+    /// Whether the tile at `x` column and `y` row is entirely sparse (never written by the
+    /// encoder, `TileByteCounts == 0`). `false` for a planar tile with only some bands
+    /// sparse. Returns `None` if this is not a tiled TIFF.
+    pub fn is_tile_sparse(&self, x: usize, y: usize) -> Option<bool> {
+        match self.tile_byte_range(x, y)? {
+            TileByteRange::Chunky(range) => Some(range.is_empty()),
+            TileByteRange::Planar(ranges) => Some(ranges.iter().all(|r| r.is_empty())),
+        }
+    }
+
     /// Fetch the tile located at `x` column and `y` row using the provided reader.
     ///
     /// For planar configuration TIFFs, this automatically fetches all bands for the tile
@@ -785,9 +795,20 @@ pub enum TileByteRange {
 impl TileByteRange {
     async fn into_fetch(self, reader: &dyn AsyncFileReader) -> AsyncTiffResult<CompressedBytes> {
         match self {
-            Self::Chunky(range) => Ok(CompressedBytes::Chunky(reader.get_bytes(range).await?)),
+            Self::Chunky(range) => {
+                if range.is_empty() {
+                    // TileByteCounts == 0: this tile was never written (a "sparse" tile, per
+                    // the TIFF6/COG convention). Don't send a 0-length range to the reader --
+                    // some backends (e.g. the `object_store`-backed ones) reject it outright.
+                    Ok(CompressedBytes::Chunky(None))
+                } else {
+                    Ok(CompressedBytes::Chunky(Some(
+                        reader.get_bytes(range).await?,
+                    )))
+                }
+            }
             Self::Planar(ranges) => Ok(CompressedBytes::Planar(
-                reader.get_byte_ranges(ranges).await?,
+                fetch_ranges_sparse_aware(reader, ranges).await?,
             )),
         }
     }
@@ -836,20 +857,20 @@ impl TilesByteRanges {
     ) -> AsyncTiffResult<Vec<CompressedBytes>> {
         match self {
             Self::Chunky(ranges) => {
-                let buffers = reader.get_byte_ranges(ranges).await?;
+                let buffers = fetch_ranges_sparse_aware(reader, ranges).await?;
                 Ok(buffers.into_iter().map(CompressedBytes::Chunky).collect())
             }
             Self::Planar(ranges) => {
                 // Record how many bands each tile has, then flatten into a single fetch
                 let band_counts: Vec<usize> = ranges.iter().map(|r| r.len()).collect();
                 let flat_ranges: Vec<Range<u64>> = ranges.into_iter().flatten().collect();
-                let flat_buffers = reader.get_byte_ranges(flat_ranges).await?;
+                let flat_buffers = fetch_ranges_sparse_aware(reader, flat_ranges).await?;
                 // Re-chunk the flat results back into per-tile band vecs
                 let mut flat_iter = flat_buffers.into_iter();
                 band_counts
                     .into_iter()
                     .map(|n| {
-                        let band_bytes: Vec<Bytes> = flat_iter.by_ref().take(n).collect();
+                        let band_bytes: Vec<Option<Bytes>> = flat_iter.by_ref().take(n).collect();
                         Ok(CompressedBytes::Planar(band_bytes))
                     })
                     .collect()
@@ -896,13 +917,17 @@ impl TilesByteRanges {
 }
 
 /// Compressed tile data, either as a single chunk (chunky) or multiple chunks (planar).
+///
+/// A `None` entry means that tile or band was never written by the encoder (sparse,
+/// `TileByteCounts == 0`); [`Tile::decode`] fills it with the nodata value instead.
 #[derive(Debug, Clone)]
 pub enum CompressedBytes {
-    /// Single compressed chunk for chunky (pixel-interleaved) format.
-    Chunky(Bytes),
+    /// Single compressed chunk for chunky (pixel-interleaved) format, or `None` if sparse.
+    Chunky(Option<Bytes>),
 
-    /// Multiple compressed chunks, one per band, for planar (band-interleaved) format.
-    Planar(Vec<Bytes>),
+    /// One compressed chunk per band for planar (band-interleaved) format, `None` per
+    /// sparse band.
+    Planar(Vec<Option<Bytes>>),
 }
 
 impl CompressedBytes {
@@ -924,6 +949,35 @@ impl CompressedBytes {
             photometric_interpretation: ifd.photometric_interpretation,
             jpeg_tables: ifd.jpeg_tables.clone(),
             lerc_parameters: ifd.lerc_parameters.clone(),
+            nodata: parse_gdal_nodata(ifd),
         }
     }
+}
+
+// Fetch only the non-empty ranges, returning `None` in place of each empty (sparse) one --
+// some readers reject a zero-length range outright, and there's nothing to fetch anyway.
+async fn fetch_ranges_sparse_aware(
+    reader: &dyn AsyncFileReader,
+    ranges: Vec<Range<u64>>,
+) -> AsyncTiffResult<Vec<Option<Bytes>>> {
+    let mut real_indices = Vec::new();
+    let mut real_ranges = Vec::new();
+    for (i, range) in ranges.iter().enumerate() {
+        if !range.is_empty() {
+            real_indices.push(i);
+            real_ranges.push(range.clone());
+        }
+    }
+
+    let fetched = reader.get_byte_ranges(real_ranges).await?;
+
+    let mut result: Vec<Option<Bytes>> = vec![None; ranges.len()];
+    for (idx, bytes) in real_indices.into_iter().zip(fetched) {
+        result[idx] = Some(bytes);
+    }
+    Ok(result)
+}
+
+fn parse_gdal_nodata(ifd: &ImageFileDirectory) -> Option<f64> {
+    ifd.gdal_nodata().and_then(|s| s.trim().parse::<f64>().ok())
 }

--- a/src/test/geotiff_test_data/rasterio_generated/mod.rs
+++ b/src/test/geotiff_test_data/rasterio_generated/mod.rs
@@ -1,5 +1,6 @@
 mod lerc;
 mod lzma;
+mod sparse;
 mod uint16;
 mod unaligned_tiles;
 mod webp;

--- a/src/test/geotiff_test_data/rasterio_generated/sparse.rs
+++ b/src/test/geotiff_test_data/rasterio_generated/sparse.rs
@@ -12,13 +12,17 @@ async fn test_sparse_tile_fills_with_nodata() {
     assert_eq!(ifd.tile_height(), Some(256));
 
     // Tile (0, 0) was actually written by GDAL.
+    assert_eq!(ifd.is_tile_sparse(0, 0), Some(false));
     let tile = ifd.fetch_tile(0, 0, &reader).await.unwrap();
+    assert!(!tile.is_sparse());
     let array = tile.decode(&Default::default()).unwrap();
     assert_eq!(array.shape(), [256, 256, 1]);
 
     // Tile (1, 0) was never written -- GDAL left it sparse. This should decode to an array
     // filled with the fixture's GDAL_NODATA value (7), not error.
+    assert_eq!(ifd.is_tile_sparse(1, 0), Some(true));
     let tile = ifd.fetch_tile(1, 0, &reader).await.unwrap();
+    assert!(tile.is_sparse());
     let array = tile.decode(&Default::default()).unwrap();
     match array.data() {
         TypedArray::UInt8(v) => assert!(v.iter().all(|&b| b == 7)),
@@ -33,6 +37,7 @@ async fn test_sparse_tile_defaults_to_zero_without_nodata() {
     let ifd = &tiff.ifds()[0];
 
     let tile = ifd.fetch_tile(1, 0, &reader).await.unwrap();
+    assert!(tile.is_sparse());
     let array = tile.decode(&Default::default()).unwrap();
     match array.data() {
         TypedArray::UInt8(v) => assert!(v.iter().all(|&b| b == 0)),

--- a/src/test/geotiff_test_data/rasterio_generated/sparse.rs
+++ b/src/test/geotiff_test_data/rasterio_generated/sparse.rs
@@ -1,0 +1,41 @@
+use crate::test::util::open_tiff;
+use crate::TypedArray;
+
+#[tokio::test]
+async fn test_sparse_tile_fills_with_nodata() {
+    let filename = "geotiff-test-data/rasterio_generated/fixtures/uint8_1band_sparse_nodata.tif";
+    let (reader, tiff) = open_tiff(filename).await;
+    let ifd = &tiff.ifds()[0];
+    assert_eq!(ifd.image_height(), 512);
+    assert_eq!(ifd.image_width(), 512);
+    assert_eq!(ifd.tile_width(), Some(256));
+    assert_eq!(ifd.tile_height(), Some(256));
+
+    // Tile (0, 0) was actually written by GDAL.
+    let tile = ifd.fetch_tile(0, 0, &reader).await.unwrap();
+    let array = tile.decode(&Default::default()).unwrap();
+    assert_eq!(array.shape(), [256, 256, 1]);
+
+    // Tile (1, 0) was never written -- GDAL left it sparse. This should decode to an array
+    // filled with the fixture's GDAL_NODATA value (7), not error.
+    let tile = ifd.fetch_tile(1, 0, &reader).await.unwrap();
+    let array = tile.decode(&Default::default()).unwrap();
+    match array.data() {
+        TypedArray::UInt8(v) => assert!(v.iter().all(|&b| b == 7)),
+        other => panic!("expected UInt8, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_sparse_tile_defaults_to_zero_without_nodata() {
+    let filename = "geotiff-test-data/rasterio_generated/fixtures/uint8_1band_sparse_no_nodata.tif";
+    let (reader, tiff) = open_tiff(filename).await;
+    let ifd = &tiff.ifds()[0];
+
+    let tile = ifd.fetch_tile(1, 0, &reader).await.unwrap();
+    let array = tile.decode(&Default::default()).unwrap();
+    match array.data() {
+        TypedArray::UInt8(v) => assert!(v.iter().all(|&b| b == 0)),
+        other => panic!("expected UInt8, got {other:?}"),
+    }
+}

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -36,6 +36,8 @@ pub struct Tile {
     /// LERC parameters from the LercParameters tag: [version, compression_type, ...]
     /// compression_type: 0 = none, 1 = deflate, 2 = zstd
     pub(crate) lerc_parameters: Option<Vec<u32>>,
+    /// The IFD's `GDAL_NODATA` value, if present; used to fill sparse tiles/bands.
+    pub(crate) nodata: Option<f64>,
 }
 
 impl Tile {
@@ -73,70 +75,72 @@ impl Tile {
         self.jpeg_tables.as_ref()
     }
 
+    /// Whether this tile is entirely sparse (never written by the encoder). `false` for a
+    /// planar tile with only some bands sparse -- inspect [`Tile::compressed_bytes`] for
+    /// per-band detail in that case.
+    pub fn is_sparse(&self) -> bool {
+        match &self.compressed_bytes {
+            CompressedBytes::Chunky(bytes) => bytes.is_none(),
+            CompressedBytes::Planar(bands) => bands.iter().all(|b| b.is_none()),
+        }
+    }
+
     /// Decode this tile to an [`Array`].
     ///
     /// Decoding is separate from data fetching so that sync and async operations do not block the
     /// same runtime.
+    ///
+    /// A sparse tile or band (see [`Tile::is_sparse`]) is filled with the nodata value
+    /// rather than decoded.
     pub fn decode(self, decoder_registry: &DecoderRegistry) -> AsyncTiffResult<Array> {
-        let decoder = decoder_registry
-            .as_ref()
-            .get(&self.compression_method)
-            .ok_or(TiffError::UnsupportedError(
-                TiffUnsupportedError::UnsupportedCompression(self.compression_method),
-            ))?;
-
         let samples = self.samples_per_pixel as usize;
         let bits_per_sample = self.bits_per_sample;
         // tile_width is the full encoded tile width — predictor must use this, not the cropped width
         let tile_width = self.width as usize;
+        let height = self.height as usize;
 
-        let mut decoded_tile = match &self.compressed_bytes {
-            CompressedBytes::Chunky(bytes) => decoder.decode_tile(
-                bytes.clone(),
-                self.photometric_interpretation,
-                self.jpeg_tables.as_deref(),
-                self.samples_per_pixel,
-                bits_per_sample,
-                self.lerc_parameters.as_deref(),
-            )?,
+        let decoded = match &self.compressed_bytes {
+            CompressedBytes::Chunky(None) => self.fill_bytes(tile_width * height * samples),
+            CompressedBytes::Chunky(Some(bytes)) => {
+                let decoder = self.get_decoder(decoder_registry)?;
+                let decoded_tile = decoder.decode_tile(
+                    bytes.clone(),
+                    self.photometric_interpretation,
+                    self.jpeg_tables.as_deref(),
+                    self.samples_per_pixel,
+                    bits_per_sample,
+                    self.lerc_parameters.as_deref(),
+                )?;
+                self.apply_predictor(decoded_tile, samples, tile_width)?
+            }
             CompressedBytes::Planar(band_bytes) => {
                 let bytes_per_sample = (bits_per_sample as usize).div_ceil(8);
-                let total_size =
-                    band_bytes.len() * tile_width * (self.height as usize) * bytes_per_sample;
-                let mut result = Vec::with_capacity(total_size);
+                let plane_len = tile_width * height * bytes_per_sample;
+                let mut result = Vec::with_capacity(band_bytes.len() * plane_len);
 
-                for band_data in band_bytes {
-                    let decoded_band = decoder.decode_tile(
-                        band_data.clone(),
-                        self.photometric_interpretation,
-                        self.jpeg_tables.as_deref(),
-                        1,
-                        bits_per_sample,
-                        self.lerc_parameters.as_deref(),
-                    )?;
-                    result.extend_from_slice(&decoded_band);
+                for band in band_bytes {
+                    let band_decoded = match band {
+                        None => self.fill_bytes(tile_width * height),
+                        Some(bytes) => {
+                            let decoder = self.get_decoder(decoder_registry)?;
+                            let decoded_band = decoder.decode_tile(
+                                bytes.clone(),
+                                self.photometric_interpretation,
+                                self.jpeg_tables.as_deref(),
+                                1,
+                                bits_per_sample,
+                                self.lerc_parameters.as_deref(),
+                            )?;
+                            // Each band is its own plane, so samples = 1 here, not
+                            // self.samples_per_pixel.
+                            self.apply_predictor(decoded_band, 1, tile_width)?
+                        }
+                    };
+                    debug_assert_eq!(band_decoded.len(), plane_len);
+                    result.extend_from_slice(&band_decoded);
                 }
 
-                debug_assert_eq!(result.len(), total_size);
                 result
-            }
-        };
-
-        // Apply predictor on the full encoded tile width, then crop afterward.
-        let decoded = match self.predictor {
-            Predictor::None => {
-                fix_endianness(&mut decoded_tile, self.endianness, bits_per_sample);
-                decoded_tile
-            }
-            Predictor::Horizontal => unpredict_hdiff(
-                decoded_tile,
-                self.endianness,
-                samples,
-                bits_per_sample,
-                tile_width,
-            ),
-            Predictor::FloatingPoint => {
-                unpredict_float(decoded_tile, samples, bits_per_sample, tile_width)?
             }
         };
 
@@ -148,6 +152,79 @@ impl Tile {
         );
         Array::try_new(decoded, shape, self.data_type)
     }
+
+    fn get_decoder<'a>(
+        &self,
+        decoder_registry: &'a DecoderRegistry,
+    ) -> AsyncTiffResult<&'a dyn crate::decoder::Decoder> {
+        let decoder = decoder_registry
+            .as_ref()
+            .get(&self.compression_method)
+            .ok_or(TiffError::UnsupportedError(
+                TiffUnsupportedError::UnsupportedCompression(self.compression_method),
+            ))?;
+        Ok(decoder.as_ref())
+    }
+
+    fn apply_predictor(
+        &self,
+        decoded: Vec<u8>,
+        samples: usize,
+        tile_width: usize,
+    ) -> AsyncTiffResult<Vec<u8>> {
+        let bits_per_sample = self.bits_per_sample;
+        Ok(match self.predictor {
+            Predictor::None => {
+                let mut decoded = decoded;
+                fix_endianness(&mut decoded, self.endianness, bits_per_sample);
+                decoded
+            }
+            Predictor::Horizontal => unpredict_hdiff(
+                decoded,
+                self.endianness,
+                samples,
+                bits_per_sample,
+                tile_width,
+            ),
+            Predictor::FloatingPoint => {
+                unpredict_float(decoded, samples, bits_per_sample, tile_width)?
+            }
+        })
+    }
+
+    /// `element_count` samples worth of already-decoded bytes, each set to the resolved
+    /// nodata value (or `0`).
+    fn fill_bytes(&self, element_count: usize) -> Vec<u8> {
+        let value = self.nodata.unwrap_or(0.0);
+        match self.data_type {
+            None | Some(DataType::UInt8) => {
+                repeat_ne_bytes((value as u8).to_ne_bytes(), element_count)
+            }
+            Some(DataType::Bool) => {
+                // Packed bit form, 1 bit per sample. Valid (true) only for an explicit
+                // non-zero nodata; default is all-invalid.
+                let byte = if value != 0.0 { 0xFF } else { 0x00 };
+                vec![byte; element_count.div_ceil(8)]
+            }
+            Some(DataType::UInt16) => repeat_ne_bytes((value as u16).to_ne_bytes(), element_count),
+            Some(DataType::UInt32) => repeat_ne_bytes((value as u32).to_ne_bytes(), element_count),
+            Some(DataType::UInt64) => repeat_ne_bytes((value as u64).to_ne_bytes(), element_count),
+            Some(DataType::Int8) => repeat_ne_bytes((value as i8).to_ne_bytes(), element_count),
+            Some(DataType::Int16) => repeat_ne_bytes((value as i16).to_ne_bytes(), element_count),
+            Some(DataType::Int32) => repeat_ne_bytes((value as i32).to_ne_bytes(), element_count),
+            Some(DataType::Int64) => repeat_ne_bytes((value as i64).to_ne_bytes(), element_count),
+            Some(DataType::Float32) => repeat_ne_bytes((value as f32).to_ne_bytes(), element_count),
+            Some(DataType::Float64) => repeat_ne_bytes(value.to_ne_bytes(), element_count),
+        }
+    }
+}
+
+fn repeat_ne_bytes<const N: usize>(sample: [u8; N], count: usize) -> Vec<u8> {
+    let mut out = Vec::with_capacity(N * count);
+    for _ in 0..count {
+        out.extend_from_slice(&sample);
+    }
+    out
 }
 
 fn infer_shape(


### PR DESCRIPTION
## Summary

GDAL/rasterio support "sparse" tiled TIFFs (`SPARSE_OK=YES`): a tile the encoder never wrote has `TileOffsets[i] == TileByteCounts[i] == 0`. Fetching one currently errors instead of decoding to a nodata-filled array:

```
TypeError: Generic LocalFileSystem error: Requested range was invalid
```

`TileByteRange::from_ifd_tile` builds `offset..offset+byte_count` unconditionally, so a sparse tile becomes the range `0..0`, which `object_store` rejects outright. No decoder can turn 0 bytes into a tile either.

## Changes

- `TileByteRange`/`TilesByteRanges::into_fetch` treat any empty range as sparse rather than fetching it, per band — a planar tile with some bands populated and others sparse works, not treated as malformed.
- `CompressedBytes::Chunky`/`Planar` now hold `Option<Bytes>` (`None` == sparse).
- `Tile` gained `nodata: Option<f64>`, parsed from the IFD's `GDAL_NODATA` tag at construction.
- `Tile::decode` fills sparse tiles/bands with that value (or `0`) instead of touching the decoder, per band.
- Predictor is now applied per-band for planar tiles (`samples = 1`), not once across the whole buffer with `samples = total-band-count` — the latter only happened to be correct for single-band planar tiles.
- New `Tile::is_sparse()` / `ImageFileDirectory::is_tile_sparse()`, exposed to Python too.

Commits: fail → fix → python bindings.

## Status

Ready for review. CI green. Blocked from merging by developmentseed/geotiff-test-data#70 — the submodule is pinned to a commit that only exists on that PR's branch, which will get a new SHA once it merges (likely squashed).

### Pre-merge checklist
- [ ] Bump the `fixtures/geotiff-test-data` submodule pin to developmentseed/geotiff-test-data#70's post-merge commit.
- [ ] Don't merge before developmentseed/geotiff-test-data#70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)